### PR TITLE
Edit footer links

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -9,21 +9,28 @@
         <h5>Documentation</h5>
         <ul class="list-unstyled text-small">
           <li>
-            <%= link_to 'Uploading data', 'https://github.com/pod4lib/aggregator/wiki/Uploading-data-using-the-API', class: 'text-muted' %>
+            <%= link_to 'POD API', 'https://github.com/pod4lib/aggregator/wiki/Uploading-data-using-the-API', class: 'text-muted' %>
           </li>
           <li>
-            <%= link_to 'Data requirements', 'https://github.com/pod4lib/aggregator/wiki/Data-requirements', class: 'text-muted' %>
+            <%= link_to 'Data documentation', 'https://github.com/pod4lib/aggregator/wiki/Data-requirements', class: 'text-muted' %>
           </li>
           <li>
-            <%= link_to 'More documentation (wiki)', 'https://github.com/pod4lib/aggregator/wiki', class: 'text-muted' %>
+            <%= link_to 'Data retention policy', 'https://github.com/pod4lib/aggregator/wiki/Retention-policy', class: 'text-muted' %>
           </li>
         </ul>
       </div>
       <div class="col-6 col-md">
         <h5>Other Resources</h5>
         <ul class="list-unstyled text-small">
-          <li><a class="text-muted" href="https://docs.google.com/document/d/1EZG7z_A13jxPfHbYhT7Ae4Ays10fhecqfoGJhqrcjD8/edit">Data Provider &amp Usage Framework</a></li>
-          <li><a class="text-muted" href="https://github.com/pod4lib/aggregator">GitHub</a></li>
+          <li>
+            <%= link_to 'Help with contributing or using POD data', 'https://github.com/pod4lib/aggregator/wiki#getting-help', class: 'text-muted' %>
+          </li>
+          <li>
+            <%= link_to 'Data provider and usage framework', 'https://docs.google.com/document/d/1EZG7z_A13jxPfHbYhT7Ae4Ays10fhecqfoGJhqrcjD8/edit', class: 'text-muted' %>
+          </li>
+          <li>
+            <%= link_to 'Github repository', 'https://github.com/pod4lib/aggregator', class: 'text-muted' %>
+          </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Fixes #429 

- Edits footer links to reflect Gary's design in ticket
- Be consistent with how we write links using `link_to`

Re: the note in the ticket to update the date in footer, it was already fixed by https://github.com/pod4lib/aggregator/pull/437