### PR TITLE
Fix logic to prevent deleted records from being included in full dumps.

### DIFF
--- a/app/jobs/generate_full_dump_job.rb
+++ b/app/jobs/generate_full_dump_job.rb
@@ -25,7 +25,7 @@ class GenerateFullDumpJob < ApplicationJob
 
       organization.default_stream.uploads.each do |upload|
         upload.each_marc_record_metadata(checksum: false).each do |record|
-          next unless hash.dig(record.marc001, 'file_id') == record.file_id || hash.dig(record.marc001, 'status') == 'delete'
+          next if hash.dig(record.marc001, 'file_id') != record.file_id || hash.dig(record.marc001, 'status') == 'delete'
 
           writer.write_marc_record(record)
         end

--- a/spec/jobs/generate_full_dump_job_spec.rb
+++ b/spec/jobs/generate_full_dump_job_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe GenerateFullDumpJob, type: :job do
     end
   end
 
+  it 'does not contain any deleted MARC records from the organization' do
+    organization.default_stream.uploads << build(:upload, :deletes)
+    described_class.perform_now(organization)
+
+    download_and_uncompress(organization.default_stream.normalized_dumps.last.marcxml) do |file|
+      expect(Nokogiri::XML(file).xpath('//marc:record', marc: 'http://www.loc.gov/MARC21/slim').count).to eq 1
+    end
+  end
+
   describe '.enqueue_all' do
     it 'enqueues jobs for each organization' do
       expect do


### PR DESCRIPTION
I _think_ this is fixing a bug and not breaking intentional behavior. Deleted records were being included in full dumps. This modifies the logic used to assemble the full dump to exclude deleted records. Closes #468 