### PR TITLE
Set filenames with appopriate extensions for full and delta dumps.

### DIFF
--- a/app/jobs/generate_delta_dump_job.rb
+++ b/app/jobs/generate_delta_dump_job.rb
@@ -41,7 +41,8 @@ class GenerateDeltaDumpJob < ApplicationJob
       writer.finalize
 
       writer.files.each do |as, file|
-        delta_dump.public_send(as).attach(io: File.open(file), filename: as)
+        delta_dump.public_send(as).attach(io: File.open(file),
+                                          filename: human_readable_filename(as))
       end
 
       delta_dump.save!
@@ -63,5 +64,22 @@ class GenerateDeltaDumpJob < ApplicationJob
     end
 
     hash
+  end
+
+  private
+
+  def human_readable_filename(file_type)
+    case file_type
+    when :deletes
+      'deletes.del.txt'
+    when :marc21
+      'marc21.mrc.gz'
+    when :marcxml
+      'marcxml.xml.gz'
+    when :errata
+      'errata.gz'
+    else
+      file_type
+    end
   end
 end

--- a/app/jobs/generate_full_dump_job.rb
+++ b/app/jobs/generate_full_dump_job.rb
@@ -50,7 +50,7 @@ class GenerateFullDumpJob < ApplicationJob
   def human_readable_filename(base_name, file_type)
     as = case file_type
          when :deletes
-           'deletes.del'
+           'deletes.del.txt'
          when :marc21
            'marc21.mrc.gz'
          when :marcxml

--- a/spec/jobs/generate_delta_dump_job_spec.rb
+++ b/spec/jobs/generate_delta_dump_job_spec.rb
@@ -30,6 +30,34 @@ RSpec.describe GenerateDeltaDumpJob, type: :job do
     end
   end
 
+  it 'has a content type of application/gzip for compressed marcxml' do
+    described_class.perform_now(organization)
+
+    expect(organization.default_stream.reload.current_full_dump.deltas.last
+                       .marcxml.attachment.blob.content_type).to eq 'application/gzip'
+  end
+
+  it 'has a filename of marcxml.xml.gz for compressed marcxml' do
+    described_class.perform_now(organization)
+
+    expect(organization.default_stream.reload.current_full_dump.deltas.last
+                       .marcxml.attachment.blob.filename).to eq 'marcxml.xml.gz'
+  end
+
+  it 'has a content type of application/gzip for compressed marc21' do
+    described_class.perform_now(organization)
+
+    expect(organization.default_stream.reload.current_full_dump.deltas.last
+                       .marc21.attachment.blob.content_type).to eq 'application/gzip'
+  end
+
+  it 'has a filename of marc21.mrc.gz for compressed marc21' do
+    described_class.perform_now(organization)
+
+    expect(organization.default_stream.reload.current_full_dump.deltas.last
+                       .marc21.attachment.blob.filename).to eq 'marc21.mrc.gz'
+  end
+
   context 'with deletes' do
     before do
       organization.default_stream.uploads << build(:upload, :deletes)
@@ -41,6 +69,20 @@ RSpec.describe GenerateDeltaDumpJob, type: :job do
       organization.default_stream.reload.current_full_dump.deltas.last.deletes.download do |file|
         expect(file.each_line.count).to eq 4
       end
+    end
+
+    it 'has a content type of text/plain for deletes' do
+      described_class.perform_now(organization)
+
+      expect(organization.default_stream.reload.current_full_dump.deltas.last
+                         .deletes.attachment.blob.content_type).to eq 'text/plain'
+    end
+
+    it 'has a filename of deletes.del.txt for deletes' do
+      described_class.perform_now(organization)
+
+      expect(organization.default_stream.reload.current_full_dump.deltas.last
+                         .deletes.attachment.blob.filename).to eq 'deletes.del.txt'
     end
 
     it 'does not include MARC records that were deleted' do

--- a/spec/jobs/generate_full_dump_job_spec.rb
+++ b/spec/jobs/generate_full_dump_job_spec.rb
@@ -43,6 +43,30 @@ RSpec.describe GenerateFullDumpJob, type: :job do
     end
   end
 
+  it 'has a content type of application/gzip for compressed marcxml' do
+    described_class.perform_now(organization)
+
+    expect(organization.default_stream.normalized_dumps.last.marcxml.attachment.blob.content_type).to eq 'application/gzip'
+  end
+
+  it 'has a filename of marcxml.xml.gz for compressed marcxml' do
+    described_class.perform_now(organization)
+
+    expect(organization.default_stream.normalized_dumps.last.marcxml.attachment.blob.filename.to_s).to match(/marcxml.xml.gz/)
+  end
+
+  it 'has a content type of application/gzip for compressed marc21' do
+    described_class.perform_now(organization)
+
+    expect(organization.default_stream.normalized_dumps.last.marc21.attachment.blob.content_type).to eq 'application/gzip'
+  end
+
+  it 'has a filename of marc21.mrc.gz for compressed marc21' do
+    described_class.perform_now(organization)
+
+    expect(organization.default_stream.normalized_dumps.last.marc21.attachment.blob.filename.to_s).to match(/marc21.mrc.gz/)
+  end
+
   describe '.enqueue_all' do
     it 'enqueues jobs for each organization' do
       expect do


### PR DESCRIPTION
Delta deletes were getting identified as MARC files and queued up for MARC profiling (and then entering a fail/retry loop in sidekiq). This change adds file extensions to the filenames generated for deltas so the file type can be more reliably identified. Also adds some tests to confirm that generated files have the expected content type and filename.