### PR TITLE
Update design for Devise pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -123,3 +123,45 @@ input[type=file][data-direct-upload-url][disabled] {
 .bg-local-practice {
   background-color: lighten($warning, 40%) !important;
 }
+
+.devise-wrap {
+  padding-top: $spacer;
+
+  h1 {
+    text-align: center;
+    padding: $spacer 0;
+  }
+
+  // the main form elements
+  form > .form-group {
+    padding-bottom: $spacer * 2;
+  }
+
+  form > .form-group:last-child {
+    border-bottom: 2px #000 solid;
+  }
+
+  form > .form-group > label {
+    padding-bottom: $spacer / 2;
+  }
+
+  .form-check {
+    margin-bottom: 0;
+    padding-left: 0;
+  }
+
+  .form-check .form-check-input {
+    // override negative margin-left from BS
+    margin-left: 0;
+    margin-right: 5px;
+  }
+
+  // additional links below main form
+  > .links-list > li {
+    padding-top: $spacer;
+  }
+
+  > .links-list > li > a {
+    text-decoration: none;
+  }
+}

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,27 +1,27 @@
-<div class="form-group">
+<ul class="list-unstyled links-list">
   <%- if controller_name != 'sessions' %>
-    <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
+    <li><%= link_to t(".sign_in"), new_session_path(resource_name) %></li>
   <% end -%>
 
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-    <%= link_to t(".sign_up"), new_registration_path(resource_name), data: { turbolinks: false } %><br />
+    <li><%= link_to t(".sign_up"), new_registration_path(resource_name), data: { turbolinks: false } %></li>
   <% end -%>
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-    <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
+    <li><%= link_to t(".forgot_your_password"), new_password_path(resource_name) %></li>
   <% end -%>
 
   <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-    <%= link_to t('.didn_t_receive_confirmation_instructions'), new_user_confirmation_path(resource_name) %><br />
+    <li><%= link_to t('.didn_t_receive_confirmation_instructions'), new_user_confirmation_path(resource_name) %></li>
   <% end -%>
 
   <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-    <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
+    <li><%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %></li>
   <% end -%>
 
   <%- if devise_mapping.omniauthable? %>
     <%- resource_class.omniauth_providers.each do |provider| %>
-      <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %><br />
+      <li><%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider) %></li>
     <% end -%>
   <% end -%>
-</div>
+</ul>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -2,7 +2,7 @@
   <%= content_for(:header) %>
 
   <div class="container">
-    <div class="col-md-8 offset-md-2 devise-wrap">
+    <div class="col-md-6 offset-md-3 devise-wrap">
       <%= yield %>
     </div>
   </div>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -2,7 +2,7 @@
   <%= content_for(:header) %>
 
   <div class="container">
-    <div class="mr-auto ml-auto w-25 mt-5 mb-5">
+    <div class="col-md-8 offset-md-2 devise-wrap">
       <%= yield %>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,7 @@
 
 en:
   hello: "Hello world"
+  helpers:
+    label:
+      user:
+        email: Email address


### PR DESCRIPTION
Fixes #444 and by extension fixes #436 @ggeisler 

Aside from HTML and CSS changes, this PR adds a new entry to `locales/en.yml` to override the default label for email addresses.

Notes:
- The button colors, which are tied to the bootstrap theme, I've left as default/primary, so for now they don't match Gary's mockups. But this should become aligned after addressing  #459

![Screen Shot 2022-03-16 at 16 39 23](https://user-images.githubusercontent.com/1328900/158709328-f465ae86-1775-4e0d-bbe6-82cb2d294297.png)
![Screen Shot 2022-03-16 at 16 38 54](https://user-images.githubusercontent.com/1328900/158709348-846a83b6-5727-4e7b-acda-48d14bfdf0ac.png)
![Screen Shot 2022-03-16 at 16 39 30](https://user-images.githubusercontent.com/1328900/158709361-3b629b51-f3e3-4928-86d6-a5504b5a5330.png)

