### PR TITLE
Return additional file metadata with stream JSON response.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ config/master.key
 *.bowerrc
 bower.json
 
+# Ignore direnv settings
+.envrc
+
 # Ignore pow environment settings
 .powenv
 

--- a/app/views/streams/show.json.jbuilder
+++ b/app/views/streams/show.json.jbuilder
@@ -10,7 +10,7 @@ json.uploads @stream.uploads do |upload|
     json.id file.id
     json.filename file.filename
     json.hash "md5:#{Base64.decode64(file.checksum).unpack1('H*')}"
-    json.type file.content_type
+    json.content_type file.content_type
     json.length file.byte_size
     json.download_url download_url(file)
   end

--- a/app/views/streams/show.json.jbuilder
+++ b/app/views/streams/show.json.jbuilder
@@ -9,6 +9,9 @@ json.uploads @stream.uploads do |upload|
   json.files upload.files do |file|
     json.id file.id
     json.filename file.filename
+    json.hash "md5:#{Base64.decode64(file.checksum).unpack1('H*')}"
+    json.type file.content_type
+    json.length file.byte_size
     json.download_url download_url(file)
   end
 end

--- a/app/views/streams/show.json.jbuilder
+++ b/app/views/streams/show.json.jbuilder
@@ -11,7 +11,7 @@ json.uploads @stream.uploads do |upload|
     json.filename file.filename
     json.hash "md5:#{Base64.decode64(file.checksum).unpack1('H*')}"
     json.content_type file.content_type
-    json.length file.byte_size
+    json.byte_size file.byte_size
     json.download_url download_url(file)
   end
 end


### PR DESCRIPTION
Part of #454. I'd like to know the file size in the stream/file JSON response in order to filter out large files from the seed data. This adds some metadata to the JSON response that's available in the ResourceSync XML response.