### PR TITLE
Add application title to copyright statement

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -118,6 +118,10 @@ input[type=file][data-direct-upload-url][disabled] {
   height: $footer-height;
   position: absolute;
   width: 100%;
+
+  .copyright-date {
+    margin-left: 2rem;
+  }
 }
 
 .bg-local-practice {

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,9 +1,10 @@
 <footer class="footer p-4">
   <div class="container">
     <div class="row">
-      <div class="col-12 col-md">
+      <div class="col-12 col-md text-muted">
         <%= inline_svg_pack_tag 'media/packs/images/pod_small.svg', width: 30, height: 30, aria_hidden: true, class: 'pod-logo-small' %>
-        <small class="d-block mb-3 mt-2 text-muted">&copy; 2020-2022</small>
+        <span>POD Aggregator</span>
+        <small class="d-block mb-3 copyright-date">&copy; 2020-2022</small>
       </div>
       <div class="col-6 col-md">
         <h5>Documentation</h5>


### PR DESCRIPTION
Our current copyright statement lacks the title of the application and looks a bit odd to me:

<img width="734" alt="Screen Shot 2022-03-30 at 6 02 01 PM" src="https://user-images.githubusercontent.com/101482/160955549-953545f5-b0f9-42a1-b462-1eb6789d6be4.png">

This PR just adds the title to the copyright statement and adjusts the alignment a bit:

<img width="734" alt="Screen Shot 2022-03-30 at 5 57 40 PM" src="https://user-images.githubusercontent.com/101482/160955672-88365ac0-5b39-43e3-a6dc-9122407731d4.png">

(I think there is more work we can do to make the footer look better, especially at smaller viewports, but that's probably not a high priority right now so just wanted to get this small update in)