### PR TITLE
Redesign edit profile page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -137,15 +137,16 @@ input[type=file][data-direct-upload-url][disabled] {
   }
 
   // the main form elements
-  form > .form-group {
-    padding-bottom: $spacer * 2;
+  .form-group {
+    padding-top: $spacer * 2;
   }
 
-  form > .form-group:last-child {
+  .form-group:last-child {
+    padding-bottom: $spacer * 2;
     border-bottom: 2px #000 solid;
   }
 
-  form > .form-group > label {
+  .form-group > label {
     padding-bottom: $spacer / 2;
   }
 
@@ -167,5 +168,20 @@ input[type=file][data-direct-upload-url][disabled] {
 
   > .links-list > li > a {
     text-decoration: none;
+  }
+}
+
+.user-profile-section {
+  margin-top: $spacer * 2;
+
+  .actions > span {
+    margin-right: $spacer * 2;
+    a {
+      text-decoration: none;
+    }
+  }
+
+  #cancel_form {
+    margin-top: $spacer * 2;
   }
 }

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Subclass of devise controller so we can control edit profile logic
+class RegistrationsController < Devise::RegistrationsController
+  protected
+
+  def update_resource(resource, params)
+    # Require current password if user is trying to change password.
+    return super if params['password']&.present?
+
+    # Allow user to update other registration info without password
+    resource.update_without_password(params.except('current_password'))
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,31 +1,54 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h1>User Profile</h1>
 
-<%= bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+<%= bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, id: 'user_form', class: 'user-profile-section'}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
-
-  <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  <div class="form-group">
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <% end %>
+  </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
 
-  <%= f.text_field :name %>
+  <div class="form-group">
+    <%= f.text_field :name %>
+  </div>
 
-  <%= f.text_field :title, label: 'Job title' %>
+  <div class="form-group">
+    <%= f.text_field :title, label: 'Job title' %>
+  </div>
 
-  <%= f.password_field :password, label: 'New password', autocomplete: "new-password", help: "#{"#{@minimum_password_length} characters minimum" if @minimum_password_length } (leave blank if you don't want to change it)" %>
-
-  <%= f.password_field :password_confirmation, label: 'New password confirmation', autocomplete: "new-password" %>
-
-  <%= f.password_field :current_password, autocomplete: "current-password", help: '(we need your current password to confirm your changes)' %>
-
-  <div class="actions">
-    <%= f.primary "Update" %>
+  <div class="actions d-flex align-items-center">
+    <span><%= f.submit "Update", class: 'btn btn-primary' %></span>
+    <span><%= link_to "Cancel", :back %></span>
   </div>
 <% end %>
 
-<h3 class="mt-3">Cancel my account</h3>
 
-<p><%= button_to "Cancel my account", registration_path(resource_name), class: 'btn btn-secondary', data: { confirm: "Are you sure?" }, method: :delete %></p>
+<%= bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, id: 'password_form', class: 'user-profile-section'}) do |f| %>
+  <h2>Change Password</h2>
 
-<%= link_to "Back", :back %>
+  <div class="form-group">
+    <%= f.password_field :current_password,vautocomplete: "current-password", help: '(We need your current password to confirm password changes)' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.password_field :password, label: "New password", autocomplete: "new-password", help: "#{"#{@minimum_password_length} characters minimum" if @minimum_password_length }" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.password_field :password_confirmation, label: "New password confirmation", autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change Password" %>
+  </div>
+<% end %>
+
+<div class='user-profile-section'>
+  <h2>Cancel Account</h2>
+  <%= button_to "Cancel my account", registration_path(resource_name), id: 'cancel_form', class: 'btn btn-danger', data: { confirm: "Are you sure you want to delete your account?" }, method: :delete %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,11 +3,15 @@ Rails.application.routes.draw do
   # Disable default Devise user registration ("Sign Up"), but support editing user profile when logged in, which is controlled by Devise's RegistrationsController
   devise_for :users, controllers: { invitations: 'organization_invitations' }, :skip => [:registrations]
     as :user do
+      # Since we skip registration above, explicity specify registration routes we need
       get 'users/edit' => 'devise/registrations#edit', as: 'edit_user_registration'
-      put 'users' => 'devise/registrations#update', as: 'user_registration'
+      delete 'users' => 'devise/registrations#destroy', as: 'delete_user'
+      # Use custom registrations controller for updating profile
+      put 'users' => 'registrations#update', as: 'user_registration'
     end
 
   root to: 'pages#home'
+
   get '/documentation/:id', to: 'pages#show', as: :pages
   get '/api', to: 'pages#api'
 

--- a/spec/features/edit_profile_spec.rb
+++ b/spec/features/edit_profile_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'editing your user profile', type: :feature do
+  context 'with a user' do
+    let(:user) { create(:user, email: 'test@stanford.edu') }
+
+    before do
+      login_as(user, scope: :user)
+    end
+
+    it 'requires current password to change password' do
+      visit '/users/edit'
+      fill_in 'user_password', with: '123'
+      click_on 'Change Password'
+      expect(page).to have_content "Current password can't be blank"
+    end
+
+    it 'allows non-password changes without passwords' do
+      visit '/users/edit'
+      fill_in 'user_name', with: 'Nice Name'
+      click_on 'Update'
+      # successful update redirects to root page
+      expect(page).to have_content 'Your account has been updated successfully'
+    end
+  end
+end

--- a/spec/routing/registrations_routing_spec.rb
+++ b/spec/routing/registrations_routing_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RegistrationsController, type: :routing do
+  describe 'routing' do
+    it 'uses local registrations_controller to send profile updates' do
+      expect(put: '/users').to route_to('registrations#update')
+    end
+
+    it 'uses devise controller for profile destroy' do
+      expect(delete: '/users').to route_to('devise/registrations#destroy')
+    end
+
+    it 'uses devise controller for profile edit page' do
+      expect(get: '/users/edit').to route_to('devise/registrations#edit')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #447 

The main change of this PR is allowing users to edit non-password items (i.e. name, email) without entering their current password. 

@ggeisler The spacing between form items is slightly taller than your design indicated but close. The helper gem that provides `bootstrap_form_for` is adding extra stuff into the form template that conflicts with CSS I wrote previously for the Devise forms. I personally don't like this gem and would be down to rip out the dependency, but I think refactoring the forms is a separate low-priority issue. I can definitely do a workaround for the spacing however, if you think it's not acceptable.

<img width="756" alt="Screen Shot 2022-03-31 at 15 54 29" src="https://user-images.githubusercontent.com/1328900/161138914-5f9237ab-3cf3-47a2-88c8-88f535c5a8d9.png">

I appreciate your analysis in the issue and agree that for now, a single vertical layout is easiest, rather than implementing tabs. Doing tabs introduced complications with routing.
