### PR TITLE
Revise job tracker design

### DIFF
--- a/app/assets/stylesheets/pod-icons.scss
+++ b/app/assets/stylesheets/pod-icons.scss
@@ -1,9 +1,23 @@
 // Access bootstrap color utility variables
 @import 'bootstrap';
 
-.pod-icon > svg, .pod-metadata-status > svg {
+.pod-icon > svg, .pod-metadata-status > svg, .pod-job-tracker-status > svg {
   height: 25px;
   width: 25px;
+}
+
+.pod-job-tracker-status {
+  &.active {
+    color: $info
+  }
+
+  &.retry {
+    color: $warning
+  }
+
+  &.dead {
+    color: $danger
+  }
 }
 
 .pod-metadata-status {

--- a/app/assets/stylesheets/pod-icons.scss
+++ b/app/assets/stylesheets/pod-icons.scss
@@ -1,7 +1,7 @@
 // Access bootstrap color utility variables
 @import 'bootstrap';
 
-.pod-icon > svg, .pod-metadata-status > svg, .pod-job-tracker-status > svg {
+.pod-icon > svg, .pod-metadata-status > svg {
   height: 25px;
   width: 25px;
 }

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -21,6 +21,7 @@ class ApplicationJob < ActiveJob::Base
   def find_or_initialize_job_tracker
     JobTracker.find_or_create_by(job_id: job_id) do |tracker|
       tracker.job_class = self.class.name
+      tracker.provider_job_id = provider_job_id
       update_job_tracker_properties(tracker)
     end
   end

--- a/app/models/job_tracker.rb
+++ b/app/models/job_tracker.rb
@@ -5,10 +5,6 @@ class JobTracker < ApplicationRecord
   belongs_to :reports_on, polymorphic: true
   belongs_to :resource, polymorphic: true
 
-  def label
-    "[#{job_class.titleize}] #{resource_label}"
-  end
-
   def resource_label
     return resource.filename if resource.is_a? ActiveStorage::Blob
     return resource.name if resource.is_a? Upload
@@ -20,10 +16,29 @@ class JobTracker < ApplicationRecord
     @status ||= ActiveJob::Status.get(job_id)
   end
 
+  def sidekiq_status
+    return 'retry' if in_retry_set?
+    return 'dead' if in_dead_set?
+
+    'active'
+  end
+
+  def in_retry_set?
+    @in_retry_set ||= sidekiq_set(Sidekiq::RetrySet).map(&:item).any? do |j|
+      j['jid'] == provider_job_id
+    end
+  end
+
+  def in_dead_set?
+    @in_dead_set ||= sidekiq_set(Sidekiq::DeadSet).map(&:item).any? do |j|
+      j['jid'] == provider_job_id
+    end
+  end
+
   def progress_label
     return number_with_delimiter(progress) unless total?
 
-    "#{number_with_delimiter(progress)} / #{number_with_delimiter(total)}"
+    "#{number_with_delimiter(progress)} of #{number_with_delimiter(total)}"
   end
 
   def progress
@@ -44,15 +59,17 @@ class JobTracker < ApplicationRecord
     status[:total]&.positive?
   end
 
-  def percent
-    return nil unless total?
-
-    (100.0 * progress) / total
-  end
-
   private
 
   def number_with_delimiter(*args)
     ActiveSupport::NumberHelper.number_to_delimited(*args)
+  end
+
+  def sidekiq_set(set)
+    set.new
+  rescue Redis::CannotConnectError => e
+    Rails.logger.info(e)
+    Honeybadger.notify(e)
+    []
   end
 end

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -27,6 +27,13 @@ class Stream < ApplicationRecord
     uploads.find_each(&:archive)
   end
 
+  def job_tracker_status_groups
+    {
+      active: job_trackers.select { |jt| !jt.in_retry_set? && !jt.in_dead_set? },
+      needs_attention: job_trackers.select { |jt| jt.in_retry_set? || jt.in_dead_set? }
+    }
+  end
+
   def marc_profile
     any = false
     profile = MarcProfile.new(count: 0, histogram_frequency: {}, record_frequency: {}, sampled_values: {})

--- a/app/views/streams/_job_status.html.erb
+++ b/app/views/streams/_job_status.html.erb
@@ -1,20 +1,50 @@
-<% if stream.job_trackers.any? %>
-  <div class="alert alert-info">
-    <h3>Processing...</h3>
-
-    <% stream.job_trackers.order(:created_at).each do |t| %>
-      <div>
-        <%= t.label %>
-
-        <%= content_tag :div, class: 'progress', title: t.progress_label do %>
-          <%= content_tag 'div', t.progress_label, title: t.progress_label, id: "status-#{t.job_id}", class: "progress-bar #{'progress-bar-striped' unless t.total?}", aria: { valuenow: t.progress, valuemin: 0, valuemax: t.total } %>
-
-          <%= javascript_tag nonce: true do -%>
-            // hack to get around the CSP policy denying inline styles...
-            document.getElementById('<%= "status-#{t.job_id}" %>').style.width = "<%= t.percent || 0 %>%";
-          <% end %>
-        <% end %>
+<div class="mb-5">
+  <h3><%= t('job_tracker.title') %></h3>
+  <div class="accordion" id="jobStatusAccordian">
+    <% stream.job_tracker_status_groups.each do |status_group, jobs| %>
+      <div class="accordion-item">
+        <h4 class="accordion-header" id="heading<%= status_group.to_s.classify %>">
+          <button class="accordion-button collapsed" type="button"
+                  data-bs-toggle="collapse" data-bs-target="#collapse<%= status_group.to_s.classify %>"
+                  aria-expanded="false" aria-controls="collapse<%= status_group.to_s.classify %>">
+            <span class="fw-bold"><%= t("job_tracker.status_group.#{status_group}") %></span>&nbsp;
+            <span class="badge <%= jobs.count > 0 ? Settings.job_status_group[status_group].badge_class : 'bg-secondary' %>">
+              <%= jobs.count %>
+            </span>
+          </button>
+        </h4>
+        <div id="collapse<%= status_group.to_s.classify %>" class="accordion-collapse collapse"
+             aria-labelledby="heading<%= status_group.to_s.classify %>" data-bs-parent="#jobStatusAccordian">
+          <div class="accordion-body">
+            <% if status_group == :needs_attention %>
+              <%= link_to('How to get help', 'https://github.com/pod4lib/aggregator/wiki#getting-help') %>
+            <% end %>
+            <table class="table table-striped mt-4">
+              <thead>
+                <tr>
+                  <th class="text-right"><%= t('job_tracker.table_heading.status') %></th>
+                  <th class="text-right"><%= t('job_tracker.table_heading.resource') %></th>
+                  <th class="text-right"><%= t('job_tracker.table_heading.job_type') %></th>
+                  <th class="text-right"><%= t('job_tracker.table_heading.progress') %></th>
+                  <th class="text-right"><%= t('job_tracker.table_heading.created_at') %></th>
+                </tr>
+              </thead>
+              <% jobs.each do |job| %>
+                <tr class="<%= "status-#{job.job_id}" %>">
+                  <td class="text-center">
+                    <%= bootstrap_icon(Settings.job_status_group[status_group].icon_class,
+                                       class: "pod-job-tracker-status #{job.sidekiq_status}")%>
+                  </td>
+                  <td class="text-right"><%= job.resource_label %></td>
+                  <td class="text-right"><%= job.job_class.titleize %></td>
+                  <td class="text-right"><%= job.progress_label %></td>
+                  <td class="text-right"><%= job.created_at %></td>
+                </tr>
+              <% end %>
+            </table>
+          </div>
+        </div>
       </div>
     <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/streams/_job_status.html.erb
+++ b/app/views/streams/_job_status.html.erb
@@ -22,23 +22,20 @@
             <table class="table table-striped mt-4">
               <thead>
                 <tr>
-                  <th class="text-right"><%= t('job_tracker.table_heading.status') %></th>
-                  <th class="text-right"><%= t('job_tracker.table_heading.resource') %></th>
-                  <th class="text-right"><%= t('job_tracker.table_heading.job_type') %></th>
-                  <th class="text-right"><%= t('job_tracker.table_heading.progress') %></th>
-                  <th class="text-right"><%= t('job_tracker.table_heading.created_at') %></th>
+                  <th class="text-center"><%= t('job_tracker.table_heading.status') %></th>
+                  <th><%= t('job_tracker.table_heading.resource') %></th>
+                  <th><%= t('job_tracker.table_heading.job_type') %></th>
+                  <th class="text-end"><%= t('job_tracker.table_heading.progress') %></th>
+                  <th><%= t('job_tracker.table_heading.created_at') %></th>
                 </tr>
               </thead>
               <% jobs.each do |job| %>
                 <tr class="<%= "status-#{job.job_id}" %>">
-                  <td class="text-center">
-                    <%= bootstrap_icon(Settings.job_status_group[status_group].icon_class,
-                                       class: "pod-job-tracker-status #{job.sidekiq_status}")%>
-                  </td>
-                  <td class="text-right"><%= job.resource_label %></td>
-                  <td class="text-right"><%= job.job_class.titleize %></td>
-                  <td class="text-right"><%= job.progress_label %></td>
-                  <td class="text-right"><%= job.created_at %></td>
+                  <td class="text-center"><%= bootstrap_icon(Settings.job_status_group[status_group].icon_class, class: "pod-job-tracker-status #{job.sidekiq_status}")%></td>
+                  <td><%= job.resource_label %></td>
+                  <td><%= job.job_class.titleize %></td>
+                  <td class="text-end"><%= job.progress_label %></td>
+                  <td><%= job.created_at %></td>
                 </tr>
               <% end %>
             </table>

--- a/app/views/streams/_job_status.html.erb
+++ b/app/views/streams/_job_status.html.erb
@@ -31,7 +31,9 @@
               </thead>
               <% jobs.each do |job| %>
                 <tr class="<%= "status-#{job.job_id}" %>">
-                  <td class="text-center"><%= bootstrap_icon(Settings.job_status_group[status_group].icon_class, class: "pod-job-tracker-status #{job.sidekiq_status}")%></td>
+                  <td class="text-center">
+                    <%= bootstrap_icon(Settings.job_status_group[status_group].icon_class, class: "pod-icon pod-job-tracker-status #{job.sidekiq_status}")%>
+                  </td>
                   <td><%= job.resource_label %></td>
                   <td><%= job.job_class.titleize %></td>
                   <td class="text-end"><%= job.progress_label %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,3 +35,14 @@ en:
     label:
       user:
         email: Email address
+  job_tracker:
+    title: Processing status of recent background jobs
+    table_heading:
+      status: Status
+      resource: Resource
+      job_type: Job type
+      progress: Completed records
+      created_at: Created at
+    status_group:
+      active: Active
+      needs_attention: Needs attention

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,14 @@ marc_fixture_seeds:
     - Princeton
     - Stanford
 
+job_status_group:
+  active:
+    icon_class: 'arrow-repeat'
+    badge_class: 'bg-primary'
+  needs_attention:
+    icon_class: 'exclamation-triangle-fill'
+    badge_class: 'bg-warning'
+
 # refer to https://icons.getbootstrap.com/ for icon class names
 metadata_status:
   success:

--- a/db/migrate/20220318122208_add_add_provider_job_id_to_job_tracker.rb
+++ b/db/migrate/20220318122208_add_add_provider_job_id_to_job_tracker.rb
@@ -1,0 +1,6 @@
+class AddAddProviderJobIdToJobTracker < ActiveRecord::Migration[7.0]
+  def change
+    add_column :job_trackers, :provider_job_id, :string
+    add_index :job_trackers, :provider_job_id
+  end
+end

--- a/db/migrate/20220318122208_add_provider_job_id_to_job_tracker.rb
+++ b/db/migrate/20220318122208_add_provider_job_id_to_job_tracker.rb
@@ -1,4 +1,4 @@
-class AddAddProviderJobIdToJobTracker < ActiveRecord::Migration[7.0]
+class AddProviderJobIdToJobTracker < ActiveRecord::Migration[7.0]
   def change
     add_column :job_trackers, :provider_job_id, :string
     add_index :job_trackers, :provider_job_id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -130,7 +130,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_07_195048) do
     t.string "job_class"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider_job_id"
     t.index ["job_id"], name: "index_job_trackers_on_job_id"
+    t.index ["provider_job_id"], name: "index_job_trackers_on_provider_job_id"
     t.index ["reports_on_type", "reports_on_id"], name: "index_job_trackers_on_reports_on_type_and_reports_on_id"
     t.index ["resource_type", "resource_id"], name: "index_job_trackers_on_resource_type_and_resource_id"
   end

--- a/spec/models/job_tracker_spec.rb
+++ b/spec/models/job_tracker_spec.rb
@@ -3,32 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe JobTracker, type: :model do
-  subject(:job_tracker) { described_class.new(attributes.merge(job_class: 'whatever', job_id: job_id)) }
+  subject(:job_tracker) do
+    described_class.new(attributes.merge(job_class: 'whatever',
+                                         job_id: job_id,
+                                         provider_job_id: provider_job_id))
+  end
 
   let(:attributes) { {} }
   let(:status_attributes) { { progress: 50, total: 100 } }
   let(:job_id) { 'job_id' }
+  let(:provider_job_id) { 'jid' }
+  let(:retry_set) { [] }
+  let(:dead_set) { [] }
 
   before do
     allow(ActiveJob::Status).to receive(:get).with(job_id).and_return(status_attributes)
-  end
-
-  describe '#label' do
-    context 'with a blob' do
-      let(:attributes) { { resource: build(:upload, :binary_marc).files.first.blob } }
-
-      it 'includes the file name' do
-        expect(job_tracker.label).to eq '[Whatever] 1297245.marc'
-      end
-    end
-
-    context 'with an upload' do
-      let(:attributes) { { resource: build(:upload, name: 'zzz') } }
-
-      it 'includes the upload name' do
-        expect(job_tracker.label).to eq '[Whatever] zzz'
-      end
-    end
+    allow(Sidekiq::RetrySet).to receive(:new).and_return(retry_set)
+    allow(Sidekiq::DeadSet).to receive(:new).and_return(dead_set)
   end
 
   describe '#status' do
@@ -37,11 +28,67 @@ RSpec.describe JobTracker, type: :model do
     end
   end
 
+  describe '#sidekiq_status' do
+    context 'when job is in the retry set' do
+      let(:retry_set) { [instance_double('job', item: { 'jid' => 'jid' })] }
+
+      it 'returns retry' do
+        expect(job_tracker.sidekiq_status).to eq 'retry'
+      end
+    end
+
+    context 'when job is in the dead set' do
+      let(:dead_set) { [instance_double('job', item: { 'jid' => 'jid' })] }
+
+      it 'returns dead' do
+        expect(job_tracker.sidekiq_status).to eq 'dead'
+      end
+    end
+
+    context 'when job is in neither the retry nor the dead set' do
+      it 'returns active' do
+        expect(job_tracker.sidekiq_status).to eq 'active'
+      end
+    end
+  end
+
+  describe '#in_retry_set?' do
+    let(:retry_set) { [instance_double('job', item: { 'jid' => 'jid' })] }
+
+    it 'returns true when the job is in the retry set' do
+      expect(job_tracker.in_retry_set?).to be true
+    end
+
+    context 'when the job is not in the retry set' do
+      let(:retry_set) { [instance_double('job', item: { 'jid' => 'someotherid' })] }
+
+      it 'returns false' do
+        expect(job_tracker.in_retry_set?).to be false
+      end
+    end
+  end
+
+  describe '#in_dead_set?' do
+    let(:dead_set) { [instance_double('job', item: { 'jid' => 'jid' })] }
+
+    it 'returns true when the job is in the dead set' do
+      expect(job_tracker.in_dead_set?).to be true
+    end
+
+    context 'when the job is not in the dead set' do
+      let(:dead_set) { [instance_double('job', item: { 'jid' => 'someotherid' })] }
+
+      it 'returns false' do
+        expect(job_tracker.in_dead_set?).to be false
+      end
+    end
+  end
+
   describe '#progress_label' do
     let(:status_attributes) { { progress: 5000, total: 12_345 } }
 
     it 'returns the current progress' do
-      expect(job_tracker.progress_label).to eq '5,000 / 12,345'
+      expect(job_tracker.progress_label).to eq '5,000 of 12,345'
     end
 
     context 'without a final total' do
@@ -83,17 +130,5 @@ RSpec.describe JobTracker, type: :model do
 
       it { is_expected.to be false }
     end
-  end
-
-  describe '#percent' do
-    subject(:percent) { job_tracker.percent }
-
-    context 'with an unknown or 0 total' do
-      let(:status_attributes) { { total: 0 } }
-
-      it { is_expected.to be_nil }
-    end
-
-    it { is_expected.to eq 50 }
   end
 end

--- a/spec/models/stream_spec.rb
+++ b/spec/models/stream_spec.rb
@@ -36,4 +36,10 @@ RSpec.describe Stream, type: :model do
       expect { stream_with_upload.archive }.to change { stream_with_upload.uploads.archived.count }.by(1)
     end
   end
+
+  describe '#job_tracker_status_groups' do
+    it 'groups the job trackers by status' do
+      expect(stream.job_tracker_status_groups).to eq({ active: [], needs_attention: [] })
+    end
+  end
 end


### PR DESCRIPTION
This refactors the job status display (and some of the underlying models) to get us closer to @ggeisler 's designs on https://github.com/pod4lib/aggregator/issues/317. I've left out displaying completed jobs for now, although it could be added later if we want. The accordions always display so that the 0 counts are visible to provide feedback that everything is ok and no jobs are processing or stuck.

Various possible display scenarios:
<img width="1360" alt="Screen Shot 2022-04-01 at 2 47 30 PM" src="https://user-images.githubusercontent.com/458247/161330158-37d7ff31-9528-4dc1-8a7a-0d2231806619.png">
<img width="1331" alt="Screen Shot 2022-04-01 at 2 47 16 PM" src="https://user-images.githubusercontent.com/458247/161330159-171873ab-725e-4908-98da-adf7e0c050ad.png">
<img width="1349" alt="Screen Shot 2022-04-01 at 2 47 08 PM" src="https://user-images.githubusercontent.com/458247/161330160-eec15e34-7e4c-4254-9633-e969b4f9771f.png">

Closes #317 

