### PR TITLE
Explicitly require rubygems/package

### DIFF
--- a/app/jobs/extract_files_job.rb
+++ b/app/jobs/extract_files_job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rubygems/package'
+
 ##
 # Job to extract tar.gz files in the background
 class ExtractFilesJob < ApplicationJob


### PR DESCRIPTION
Fixes #554 

Presumably this was no longer required by default in Ruby 3?