### PR TITLE
Add a width percentage value to fix nav overlap

### DIFF
--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-dark navbar-expand-md bg-dark" role="navigation">
   <div class="container">
     <%= link_to root_url, class: 'navbar-brand' do %>
-    <%= inline_svg_pack_tag 'media/packs/images/pod_logo.svg', height: 24, width: '', alt: '', class: 'd-inline-block align-text-top' %>
+    <%= inline_svg_pack_tag 'media/packs/images/pod_logo.svg', height: 24, width: '33%', alt: '', class: 'd-inline-block align-text-top' %>
     <span class="ms-1"><%= t('.brand') %></span>
     <% end %>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"


### PR DESCRIPTION
Fixes [#579 ](https://github.com/pod4lib/aggregator/issues/579)
Tested in Chrome and Firefox on Mac and PC (using Cross Browser Testing platform)