### PR TITLE
Restrict access to activity page

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,7 +2,7 @@
 
 # Some site-wide dashboards
 class DashboardController < ApplicationController
-  skip_authorization_check only: [:uploads]
+  authorize_resource :class => :controller
 
   def uploads
     @uploads = Upload.accessible_by(current_ability).order(updated_at: :desc).page(params[:page])

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,7 +2,7 @@
 
 # Some site-wide dashboards
 class DashboardController < ApplicationController
-  authorize_resource :class => :controller
+  authorize_resource class: :controller
 
   def uploads
     @uploads = Upload.accessible_by(current_ability).order(updated_at: :desc).page(params[:page])

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -48,6 +48,7 @@ class Ability
     can :manage, :all if user.has_role?(:admin)
     cannot :delete, Stream, default: true
     can :read, Organization, public: true
+    can :manage, :dashboard_controller if user.has_role?(:admin)
 
     owned_orgs = Organization.with_role(:owner, user).pluck(:id)
     can :manage, Organization, id: owned_orgs

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,6 +6,7 @@ class Ability
   attr_reader :allowlisted_jwt, :user
 
   # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def initialize(user, token = nil)
     alias_action :create, :read, :update, :destroy, to: :crud
 
@@ -65,4 +66,5 @@ class Ability
     can :read, ActiveStorage::Attachment, { record: { organization: { id: member_orgs } } }
   end
   # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 end

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -11,7 +11,9 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav ms-md-5">
         <li class='nav-item'><%= link_to t('.providers'), organizations_url, class: 'nav-link' %></li>
+        <% if can? :manage, :dashboard_controller %>
         <li class='nav-item'><%= link_to t('.activity'), activity_url, class: 'nav-link', data: { turbolinks: false } %></li>
+        <% end %>
         <% if can? :manage, User %>
         <li class='nav-item'><%= link_to t('.users'), site_users_url, class: 'nav-link' %></li>
         <% end %>


### PR DESCRIPTION
Fixes [#589](https://github.com/pod4lib/aggregator/issues/589)
Restricts access to the activity page in the dashboard controller