### PR TITLE
Update normalized dumps to use records from the database instead of reading from the original files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,3 +115,4 @@ group :deployment do
   gem 'capistrano-shared_configs'
   gem 'dlss-capistrano'
 end
+gem 'concurrent-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -490,6 +490,7 @@ DEPENDENCIES
   capistrano-shared_configs
   capybara
   chartkick
+  concurrent-ruby
   config
   debug
   devise

--- a/app/controllers/streams_controller.rb
+++ b/app/controllers/streams_controller.rb
@@ -53,10 +53,7 @@ class StreamsController < ApplicationController
     @stream = @organization.streams.find(params[:stream])
     authorize!(:update, @stream)
 
-    Stream.transaction do
-      @organization.default_stream.update(default: false)
-      @stream.update(default: true)
-    end
+    @stream.make_default
 
     respond_to do |format|
       format.html { redirect_to @organization, notice: 'Stream was successfully updated.' }

--- a/app/jobs/generate_delta_dump_job.rb
+++ b/app/jobs/generate_delta_dump_job.rb
@@ -20,6 +20,10 @@ class GenerateDeltaDumpJob < ApplicationJob
 
     return unless uploads.any?
 
+    uploads.where.not(status: 'processed').each do |upload|
+      ExtractMarcRecordMetadataJob.perform_now(upload)
+    end
+
     progress.total = uploads.sum(&:marc_records_count)
 
     delta_dump = full_dump.deltas.create(stream_id: full_dump.stream_id)

--- a/app/jobs/generate_delta_dump_job.rb
+++ b/app/jobs/generate_delta_dump_job.rb
@@ -3,6 +3,8 @@
 ##
 # Background job to create a delta dump download for a resource (organization)
 class GenerateDeltaDumpJob < ApplicationJob
+  with_job_tracking
+
   def self.enqueue_all
     Organization.find_each { |org| GenerateDeltaDumpJob.perform_later(org) }
   end
@@ -17,6 +19,8 @@ class GenerateDeltaDumpJob < ApplicationJob
     uploads = organization.default_stream.uploads.where(updated_at: from...now)
 
     return unless uploads.any?
+
+    progress.total = uploads.sum(&:marc_records_count)
 
     delta_dump = full_dump.deltas.create(stream_id: full_dump.stream_id)
 

--- a/app/jobs/generate_full_dump_job.rb
+++ b/app/jobs/generate_full_dump_job.rb
@@ -19,6 +19,10 @@ class GenerateFullDumpJob < ApplicationJob
     now = Time.zone.now
     uploads = Upload.active.where(stream: organization.default_stream)
 
+    uploads.where.not(status: 'processed').each do |upload|
+      ExtractMarcRecordMetadataJob.perform_now(upload)
+    end
+
     progress.total = uploads.sum(&:marc_records_count)
 
     full_dump = organization.default_stream.normalized_dumps.build(last_full_dump_at: now, last_delta_dump_at: now)

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -13,6 +13,7 @@ class Stream < ApplicationRecord
   has_many :normalized_dumps, dependent: :destroy
   has_many :job_trackers, dependent: :delete_all, as: :reports_on
 
+  scope :default, -> { where(default: true) }
   scope :active, -> { where(status: 'active') }
   scope :archived, -> { where(status: 'archived') }
 
@@ -25,6 +26,13 @@ class Stream < ApplicationRecord
   def archive
     update(status: 'archived', default: false)
     uploads.find_each(&:archive)
+  end
+
+  def make_default
+    Stream.transaction do
+      organization.streams.default.each { |stream| stream.update(default: false) }
+      update(default: true)
+    end
   end
 
   def job_tracker_status_groups

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -12,18 +12,22 @@ class Upload < ApplicationRecord
   validates :url, presence: true, if: proc { |upload| upload.files.blank? }
   validates :files, presence: true, if: proc { |upload| upload.url.blank? }
   validate :valid_url, if: proc { |upload| upload.url.present? }
-  scope :active, -> { where(status: 'active') }
+  scope :active, -> { where(status: %w[active processed]) }
   scope :archived, -> { where(status: 'archived') }
 
   after_create :attach_file_from_url
 
   has_many_attached :files
 
-  after_save_commit :perform_extract_marc_record_metadata_job
+  after_save_commit :perform_extract_marc_record_metadata_job, if: :active?
   after_save_commit :perform_extract_files_job, if: :active?
 
   def active?
     status == 'active'
+  end
+
+  def processed?
+    status == 'processed'
   end
 
   def name

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -101,11 +101,9 @@ class Upload < ApplicationRecord
     service.each_with_metadata do |record, metadata|
       out = MarcRecord.new(
         **metadata,
-        marc001: record['001']&.value,
         file: file,
         marc: record,
-        upload: self,
-        json: Zlib::Deflate.new.deflate(record.to_marchash.to_json, Zlib::FINISH)
+        upload: self
       )
 
       out.checksum ||= Digest::MD5.hexdigest(record.to_xml.to_s) if checksum

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -35,8 +35,8 @@ class Upload < ApplicationRecord
     files.find_each(&:purge_later)
   end
 
-  def each_marc_record_metadata(**options, &block)
-    return to_enum(:each_marc_record_metadata, **options) unless block
+  def read_marc_record_metadata(**options, &block)
+    return to_enum(:read_marc_record_metadata, **options) unless block
 
     files.each do |file|
       service = MarcRecordService.new(file.blob)

--- a/app/services/normalized_marc_record_reader.rb
+++ b/app/services/normalized_marc_record_reader.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Utility class for reading marc records out of a set of uploads
+# and filtering any obsolete records so we only get the latest
+# version of each record.
+class NormalizedMarcRecordReader
+  include Enumerable
+
+  attr_reader :uploads, :thread_pool_size
+
+  # @param [Array<Upload>] uploads
+  def initialize(uploads, thread_pool_size: 10)
+    @uploads = uploads
+    @thread_pool_size = thread_pool_size
+  end
+
+  # @yield [MarcRecord]
+  def each(&block)
+    pool = Concurrent::FixedThreadPool.new(thread_pool_size)
+
+    current_marc_record_ids.each_slice(1000) do |slice|
+      records = MarcRecord.find(slice)
+
+      # do a little pre-processing to pre-generated the augmented MARC.
+      # this is done in a thread pool for a marginal performance boost
+      # (10-15%).
+      records.each do |record|
+        pool.post { record.augmented_marc }
+      rescue StandardError
+        nil
+      end
+
+      records.each(&block)
+    end
+
+    pool.shutdown
+  end
+
+  # Return the full list of MarcRecord id values to include in the dump.
+  # Note: ideally we'd be able to iterate through that list, but e.g. #find_each
+  #   does not support custom ordering (which we need in order to ensure we identify
+  #   the most recent record for each 001)
+  # @return [Array<Integer>] the list of MarcRecord id values
+  def current_marc_record_ids
+    return __pgsql_current_marc_record_ids if using_postgres?
+
+    hash = {}
+
+    # But for other databases, we'll have to do it ourselves.
+    MarcRecord.select(:marc001, :id).where(upload: uploads).order(file_id: :asc, id: :asc).each do |record|
+      hash[record.marc001] = record.id
+    end
+
+    hash.values
+  end
+
+  private
+
+  def using_postgres?
+    defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) &&
+      ActiveRecord::Base.connection == ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+  end
+
+  def __pgsql_current_marc_record_ids
+    # Postgres has 'SELECT DISTINCT ON', so we can have the database de-dupe marc records with the same 001
+    # and return the most recent
+    inner_query = MarcRecord.select('DISTINCT ON (marc001) *').where(upload: uploads).order('marc001, file_id DESC, id ASC')
+
+    MarcRecord.from(inner_query, :marc_records).order(file_id: :asc, id: :asc).pluck(:id)
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,7 @@ marc_fixture_seeds:
   host: https://pod.stanford.edu
   token: ''
   upload_count: 5
+  file_count: 5
   organizations:
     - Cornell
     - Princeton

--- a/db/migrate/20220413204319_add_marc_records_count_to_uploads.rb
+++ b/db/migrate/20220413204319_add_marc_records_count_to_uploads.rb
@@ -1,0 +1,5 @@
+class AddMarcRecordsCountToUploads < ActiveRecord::Migration[7.0]
+  def change
+    add_column :uploads, :marc_records_count, :bigint, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_07_195048) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_13_204319) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -237,6 +237,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_07_195048) do
     t.integer "allowlisted_jwts_id"
     t.string "ip_address"
     t.string "status", default: "active"
+    t.bigint "marc_records_count", default: 0
     t.index ["status"], name: "index_uploads_on_status"
     t.index ["stream_id"], name: "index_uploads_on_stream_id"
   end

--- a/spec/jobs/extract_marc_record_metadata_job_spec.rb
+++ b/spec/jobs/extract_marc_record_metadata_job_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe ExtractMarcRecordMetadataJob, type: :job do
     expect(JobTracker.last).to have_attributes(resource: upload, reports_on: upload.stream)
   end
 
+  it 'marks the upload as processed' do
+    expect do
+      described_class.perform_now(upload)
+    end.to change(upload, :processed?).from(false).to(true)
+  end
+
+  it 'records the number of records extracted' do
+    expect do
+      described_class.perform_now(upload)
+    end.to change(upload, :marc_records_count).from(0).to(1)
+  end
+
   it 'cleans up job tracking after running' do
     described_class.perform_later(upload)
     perform_enqueued_jobs

--- a/spec/jobs/generate_delta_dump_job_spec.rb
+++ b/spec/jobs/generate_delta_dump_job_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe GenerateDeltaDumpJob, type: :job do
     organization.default_stream.uploads << build(:upload, :binary_marc)
   end
 
+  it 'runs the ExtractMarcRecordMetadataJob for each upload if needed' do
+    expect do
+      described_class.perform_now(organization)
+    end.to change(MarcRecord, :count).from(2).to(3)
+  end
+
   it 'creates a new normalized delta dump' do
     expect do
       described_class.perform_now(organization)

--- a/spec/jobs/generate_full_dump_job_spec.rb
+++ b/spec/jobs/generate_full_dump_job_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe GenerateFullDumpJob, type: :job do
     organization.default_stream.uploads << build(:upload, :binary_marc)
   end
 
+  it 'runs the ExtractMarcRecordMetadataJob for each upload if needed' do
+    expect do
+      described_class.perform_now(organization)
+    end.to change(MarcRecord, :count).from(0).to(3)
+  end
+
   it 'creates a new normalized dump' do
     expect do
       described_class.perform_now(organization)

--- a/spec/models/custom_marc_writer_spec.rb
+++ b/spec/models/custom_marc_writer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CustomMarcWriter do
   let(:split_marc_records) do
     MARC::Reader.new(
       StringIO.new(
-        described_class.encode(long_upload.each_marc_record_metadata.first.marc)
+        described_class.encode(long_upload.read_marc_record_metadata.first.marc)
       )
     ).to_a
   end

--- a/spec/models/stream_spec.rb
+++ b/spec/models/stream_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Stream, type: :model do
-  subject(:stream) { described_class.new }
+  subject(:stream) { create(:stream, organization: organization) }
+
+  let(:organization) { create(:organization) }
 
   describe '#display_name' do
     it 'defaults to the name of the stream' do
@@ -40,6 +42,17 @@ RSpec.describe Stream, type: :model do
   describe '#job_tracker_status_groups' do
     it 'groups the job trackers by status' do
       expect(stream.job_tracker_status_groups).to eq({ active: [], needs_attention: [] })
+    end
+  end
+
+  describe '#make_default' do
+    let!(:current_default) { create(:stream, organization: organization, default: true) }
+
+    it 'makes the current stream the only default' do
+      expect do
+        stream.make_default
+      end.to(change(stream, :default).from(false).to(true)
+         .and((change { current_default.reload.default }).from(true).to(false)))
     end
   end
 end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -55,11 +55,11 @@ RSpec.describe Upload, type: :model do
     end
   end
 
-  describe '#each_marc_record_metadata' do
+  describe '#read_marc_record_metadata' do
     subject(:upload) { create(:upload, :small_batch_gz) }
 
     it 'uses the same object for the upload' do
-      first, second = upload.each_marc_record_metadata.first(2).map(&:upload)
+      first, second = upload.read_marc_record_metadata.first(2).map(&:upload)
 
       expect(first.object_id).to eq second.object_id
     end


### PR DESCRIPTION
150k MARCXML records
----
Before: 1813508.49ms
After: 1138422.04ms (63%)
With the thread pool: 992192.97ms (54%)
With postgres: TBD

10k  MARC21 records
----
Before: 193104.13ms
After: 178336.72ms (92%)
With the thread pool: 161627.39ms (84%)
With postgres: TBD

