### PR TITLE
Update instances of title-case to sentence-case

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>User Profile</h1>
+<h1>User profile</h1>
 
 <%= bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, id: 'user_form', class: 'user-profile-section'}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -29,7 +29,7 @@
 
 
 <%= bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, id: 'password_form', class: 'user-profile-section'}) do |f| %>
-  <h2>Change Password</h2>
+  <h2>Change password</h2>
 
   <div class="form-group">
     <%= f.password_field :current_password,vautocomplete: "current-password", help: '(We need your current password to confirm password changes)' %>
@@ -44,11 +44,11 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Change Password" %>
+    <%= f.submit "Change password" %>
   </div>
 <% end %>
 
 <div class='user-profile-section'>
-  <h2>Cancel Account</h2>
+  <h2>Cancel account</h2>
   <%= button_to "Cancel my account", registration_path(resource_name), id: 'cancel_form', class: 'btn btn-danger', data: { confirm: "Are you sure you want to delete your account?" }, method: :delete %>
 </div>

--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -1,7 +1,7 @@
 <%= bootstrap_form_with(model: organization, local: true) do |form| %>
   <%= form.text_field :name %>
   <%= form.text_field :slug %>
-  <%= form.text_field :code, help: 'LoC MARC Organization Code' %>
+  <%= form.text_field :code, help: 'LoC MARC organization code' %>
   <%= form.check_box :provider %>
 
   <div class="custom-file mb-3">

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -62,7 +62,7 @@
 
   <br>
   <% if can? :manage, Organization %>
-    <%= link_to 'New Organization', new_organization_path, class: 'btn btn-primary' if can? :create, Organization.new %>
+    <%= link_to 'New organization', new_organization_path, class: 'btn btn-primary' if can? :create, Organization.new %>
   <% end %>
 
 </div>

--- a/app/views/shared/_manage_organization_header.html.erb
+++ b/app/views/shared/_manage_organization_header.html.erb
@@ -1,9 +1,9 @@
 <div class="d-flex flex-row">
     <h1>
         <% if can? :edit, @organization %>
-            <%= 'Manage Organization'%>
+            <%= 'Manage organization'%>
         <% else %>
-            <%='View Organization' %>
+            <%='View organization' %>
         <% end %>
     </h1>
 </div>

--- a/app/views/shared/_organization_header.html.erb
+++ b/app/views/shared/_organization_header.html.erb
@@ -11,12 +11,12 @@
         </h1>
 
         <p class="lead p-2">
-          MARC Organization Code: <%= @organization.code %>
+          MARC organization code: <%= @organization.code %>
         </p>
 
         <div class="ms-auto p-2">
           <% if current_page?(organization_path(@organization)) %>
-            <%= link_to can?(:edit, @organization) ? 'Manage Organization' : 'View Organization Details', organization_users_path(@organization), class: 'align-self-center' %>
+            <%= link_to can?(:edit, @organization) ? 'Manage organization' : 'View organization details', organization_users_path(@organization), class: 'align-self-center' %>
           <% else %>
             <%= link_to 'Default stream', organization_path(@organization), class: 'align-self-center' %>
           <% end %>

--- a/app/views/streams/profile.html.erb
+++ b/app/views/streams/profile.html.erb
@@ -14,7 +14,7 @@
     <div class="alert alert-info">
       No MARC profiling data found.<br />
 
-      <%= link_to 'Reanalyze', reanalyze_organization_stream_path(@organization, @stream), method: :post, class: 'btn btn-secondary align-self-center mt-3' if can?(:reanalyze, @stream) %>
+      <%= link_to 'Re-analyze', reanalyze_organization_stream_path(@organization, @stream), method: :post, class: 'btn btn-secondary align-self-center mt-3' if can?(:reanalyze, @stream) %>
     </div>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,10 +35,10 @@ en:
   pages:
     data:
       guidelines:
-        body_html: Data in the lake is available to any POD participant to extract and reuse. It is up to the POD participant to consume and reuse the data responsibly. Libraries that seek to use POD data for uses that exceed the Minimum Standard for Data Reuse for Data Providers should exercise caution and investigate whether restrictions may apply to their intended use. This may include informing POD data provider contacts of the intended use.
+        body_html: Data in the lake is available to any POD participant to extract and reuse. It is up to the POD participant to consume and reuse the data responsibly. Libraries that seek to use POD data for uses that exceed the "minimum standard for data reuse for data providers" guidelines should exercise caution and investigate whether restrictions may apply to their intended use. This may include informing POD data provider contacts of the intended use.
         header: Guidelines for data consumers
         list_items:
-        - See the <a href='https://docs.google.com/document/d/1EZG7z_A13jxPfHbYhT7Ae4Ays10fhecqfoGJhqrcjD8/edit'>Data Provider and Usage Framework for POD</a> document for a description of the "Minimum Standard for Data Reuse for Data Providers" and related context.
+        - See the <a href='https://docs.google.com/document/d/1EZG7z_A13jxPfHbYhT7Ae4Ays10fhecqfoGJhqrcjD8/edit'>Data provider and usage framework for POD</a> document for a description of the "Minimum standard for data reuse for data providers" and related context.
         - You can find a contact link for each POD data provider in the organization banner at the top of their provider page in the POD Aggregator application.
       harvesting:
         body_html: Data providers contribute their data to POD Aggregator by uploading data sets, and data consumers download data for downstream use.
@@ -57,7 +57,7 @@ en:
           one: POD Aggregator currently holds <b>1 record</b>.
           other: POD Aggregator currently holds a total of <b>%{total_records} records</b>, of which <b>%{unique_records} are unique</b>.
           zero: POD Aggregator currently holds no records.
-        heading: POD Data
+        heading: POD data
       hero: The POD Aggregator is an open source system to aggregate MARC bibliographic and holdings data for institutions that participate in the Platform for Open Data (POD) initiative.
       login:
         button: Login
@@ -87,7 +87,7 @@ en:
           all: View all stream files ...
           heading: Latest uploads
       providers:
-        heading: POD Providers
+        heading: POD providers
         providers_html:
           one: There is currently <b>1</b> data provider.
           other: There are currently <b>%{count}</b> data providers.
@@ -105,7 +105,7 @@ en:
         contributing: Help with contributing or using POD data
         framework: Data provider and usage framework
         github: GitHub repository
-        heading: Other Resources
+        heading: Other resources
     nav:
       activity: Activity
       brand: Aggregator
@@ -121,7 +121,7 @@ en:
   site_users:
     index:
       add_admin: Add admin role
-      is_admin: POD Admin?
+      is_admin: POD admin?
       organization: Organization
       remove_admin: Remove admin role
       title: Manage users

--- a/spec/features/edit_profile_spec.rb
+++ b/spec/features/edit_profile_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'editing your user profile', type: :feature do
     it 'requires current password to change password' do
       visit '/users/edit'
       fill_in 'user_password', with: '123'
-      click_on 'Change Password'
+      click_on 'Change password'
       expect(page).to have_content "Current password can't be blank"
     end
 

--- a/spec/features/providers_spec.rb
+++ b/spec/features/providers_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Viewing provider information', type: :feature do
       # don't confuse "Edit" with "Edit Profile" in header nav
       expect(page).to have_link('Edit', exact: true)
       expect(page).to have_link 'Destroy'
-      expect(page).to have_link 'New Organization'
+      expect(page).to have_link 'New organization'
     end
   end
 


### PR DESCRIPTION
Closes #575.

We currently use a mix of sentence- and title-case in application headings, button labels, etc. This PR updates instances where we are using title-case (e.g., "New Organization") to be sentence-case ("New organization").

