### PR TITLE
Organization page updates for consumers

### DIFF
--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -3,19 +3,6 @@
   height: 20px;
 }
 
-// Single organization
-.organization {
-  .organization-icon {
-    height: 50px;
-    padding-right: 0.5rem;
-    vertical-align: bottom;
-  }
-
-  .lead {
-    margin-bottom: 0.25rem;
-  }
-}
-
 // Access bootstrap color utility variables
 @import 'bootstrap';
 

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,11 +1,9 @@
 <%= render 'shared/organization_header' %>
-
 <div class="container manage-organization-container">
+  <% if @organization.provider? %>
   <%= render 'streams/header', stream: @organization.default_stream %>
   <%= render 'shared/provider_page_header'%>
-
   <h3>Uploaded files</h3>
-  
   <%= render 'streams/stream_uploads', stream: @organization.default_stream, uploads: @uploads %>
-
+  <% end %>
 </div>

--- a/app/views/shared/_manage_organization_header.html.erb
+++ b/app/views/shared/_manage_organization_header.html.erb
@@ -10,13 +10,12 @@
 <div class="d-flex flex-row justify-content-center">
     <div class="btn-group manage-organization-tabs" role="group" aria-label="Manage organization tabs">
         <%= link_to "Users", organization_users_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_users_path(@organization))}" %>
-
-        <% if can? :read, @organization.allowlisted_jwts.build %>
-          <%= link_to "Access tokens", organization_allowlisted_jwts_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_allowlisted_jwts_path(@organization))}" %>
+        <% if @organization.provider? && can? :read, @organization.allowlisted_jwts.build %>
+        <%= link_to "Access tokens", organization_allowlisted_jwts_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_allowlisted_jwts_path(@organization))}" %>
         <% end %>
-
         <%= link_to "Organization details", organization_details_organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_details_organization_path(@organization))}" %>
-
+        <% if @organization.provider? %>
         <%= link_to "Provider details", provider_details_organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(provider_details_organization_path(@organization))}" %>
+        <% end %>
     </div>
 </div>

--- a/app/views/shared/_manage_organization_header.html.erb
+++ b/app/views/shared/_manage_organization_header.html.erb
@@ -10,7 +10,7 @@
 <div class="d-flex flex-row justify-content-center">
     <div class="btn-group manage-organization-tabs" role="group" aria-label="Manage organization tabs">
         <%= link_to "Users", organization_users_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_users_path(@organization))}" %>
-        <% if @organization.provider? && can? :read, @organization.allowlisted_jwts.build %>
+        <% if @organization.provider? && can?(:read, @organization.allowlisted_jwts.build) %>
         <%= link_to "Access tokens", organization_allowlisted_jwts_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_allowlisted_jwts_path(@organization))}" %>
         <% end %>
         <%= link_to "Organization details", organization_details_organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_details_organization_path(@organization))}" %>

--- a/app/views/shared/_manage_organization_header.html.erb
+++ b/app/views/shared/_manage_organization_header.html.erb
@@ -10,7 +10,7 @@
 <div class="d-flex flex-row justify-content-center">
     <div class="btn-group manage-organization-tabs" role="group" aria-label="Manage organization tabs">
         <%= link_to "Users", organization_users_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_users_path(@organization))}" %>
-        <% if @organization.provider? && can?(:read, @organization.allowlisted_jwts.build) %>
+        <% if can? :read, @organization.allowlisted_jwts.build %>
         <%= link_to "Access tokens", organization_allowlisted_jwts_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_allowlisted_jwts_path(@organization))}" %>
         <% end %>
         <%= link_to "Organization details", organization_details_organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_details_organization_path(@organization))}" %>

--- a/app/views/shared/_organization_header.html.erb
+++ b/app/views/shared/_organization_header.html.erb
@@ -12,7 +12,9 @@
         <% if @organization.provider? && @organization.code.present? %>
         <span class="lead"><%= t('.marc_code', code: @organization.code) %></span>
         <% end %>
-        <span class="lead"><%= t('.contact_html', mailto: mail_to(@organization.contact_emails.first)) %></span>
+        <% if @organization.contact_emails.any? %>
+        <span class="lead"><%= mail_to @organization.contact_emails.first, t('.contact') %></span>
+        <% end %>
       </div>
       <div class="ms-auto">
         <% if current_page?(organization_path(@organization)) %>

--- a/app/views/shared/_organization_header.html.erb
+++ b/app/views/shared/_organization_header.html.erb
@@ -1,31 +1,28 @@
 <% content_for :org_header do %>
-  <div class="position-relative overflow-hidden mb-4 pb-2 pt-4 bg-light organization border-bottom">
-    <div class="container">
-      <div class="d-flex">
-
-        <h1 class="display-5 font-weight-normal p-2 pe-4">
-          <% if @organization.icon.attached? %>
-            <%= image_tag(@organization.icon, class: 'organization-icon') %>
-          <% end %>
-          <%= @organization.name %>
-        </h1>
-
-        <p class="lead p-2">
-          MARC organization code: <%= @organization.code %>
-        </p>
-
-        <div class="ms-auto p-2">
-          <% if current_page?(organization_path(@organization)) %>
-            <%= link_to can?(:edit, @organization) ? 'Manage organization' : 'View organization details', organization_users_path(@organization), class: 'align-self-center' %>
-          <% else %>
-            <%= link_to 'Default stream', organization_path(@organization), class: 'align-self-center' %>
-          <% end %>
-        </div>
+<div class="position-relative overflow-hidden mb-5 py-4 bg-light organization border-bottom">
+  <div class="container">
+    <div class="d-flex align-items-center">
+      <% if @organization.icon.attached? %>
+      <%= image_tag(@organization.icon, class: 'me-2', height: 50) %>
+      <% end %>
+      <h1 class="display-5 font-weight-normal m-0">
+        <%= @organization.name %>
+      </h1>
+      <div class="d-flex flex-column ms-4">
+        <% if @organization.provider? && @organization.code.present? %>
+        <span class="lead"><%= t('.marc_code', code: @organization.code) %></span>
+        <% end %>
+        <span class="lead"><%= t('.contact_html', mailto: mail_to(@organization.contact_emails.first)) %></span>
       </div>
-
-
-
-      <%= yield %>
+      <div class="ms-auto">
+        <% if current_page?(organization_path(@organization)) %>
+        <%= link_to can?(:edit, @organization) ? t('.manage_org') : t('.view_org'), organization_users_path(@organization), class: 'align-self-center' %>
+        <% elsif @organization.provider? %>
+        <%= link_to t('.default_stream'), organization_path(@organization), class: 'align-self-center' %>
+        <% end %>
+      </div>
     </div>
+    <%= yield %>
   </div>
+</div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,7 +132,7 @@ en:
       users: Users
       view_org_page: "%{org} POD"
     organization_header:
-      contact_html: 'Contact: %{mailto}'
+      contact: POD contact for this organization
       default_stream: Default stream
       manage_org: Manage organization
       marc_code: 'MARC organization code: %{code}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,6 +131,12 @@ en:
       providers: Providers
       users: Users
       view_org_page: "%{org} POD"
+    organization_header:
+      contact_html: 'Contact: %{mailto}'
+      default_stream: Default stream
+      manage_org: Manage organization
+      marc_code: 'MARC organization code: %{code}'
+      view_org: View organization details
   site_users:
     index:
       add_admin: Add admin role


### PR DESCRIPTION
This PR does a few small, related things:

- Remove stream display from consumer org homepage (there's nothing to display here, at present)
- Update organization view/manage pages for consumer orgs (#535)

It also updates the org header layout slightly to remove unneeded CSS and align everything depending on what content is available. e.g. for a provider org with logo, MARC code, and contact email:

![Screen Shot 2022-04-19 at 15 09 18](https://user-images.githubusercontent.com/4924494/164109995-49ff3296-3515-44d3-a3ec-4c63e056a519.png)

but for a consumer org with no logo and no MARC code:

![Screen Shot 2022-04-19 at 15 09 36](https://user-images.githubusercontent.com/4924494/164109985-4364d0af-33de-4803-91c3-69cddf68e656.png)

(flexbox highlighted to show the alignment logic).

the contact email logic assumes `Organization.contact_emails` will still exist; that's easy enough to change with #544 if we do so. this PR thus fixes/refs #545.
