### PR TITLE
Do not show token tab unless user can view. Allow any user to view processing status.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -45,7 +45,7 @@ class Ability
       can :read, MarcRecord, upload: { organization: { public: true } }
       can %i[read profile info], [Stream, Upload], organization: { public: true }
       can :read, :pages_data
-      can %i[read users organization_details provider_details normalized_data], Organization, public: true
+      can %i[read users organization_details provider_details normalized_data processing_status], Organization, public: true
     end
 
     can :manage, :all if user.has_role?(:admin)

--- a/app/views/organizations/processing_status.html.erb
+++ b/app/views/organizations/processing_status.html.erb
@@ -6,6 +6,6 @@
 
   <h2><%= t('job_tracker.title') %></h2>
 
-  <%= render 'streams/job_status', stream: @organization.default_stream if can? :update, @organization.default_stream %>
+  <%= render 'streams/job_status', stream: @organization.default_stream %>
 
 </div>

--- a/app/views/shared/_manage_organization_header.html.erb
+++ b/app/views/shared/_manage_organization_header.html.erb
@@ -11,7 +11,9 @@
     <div class="btn-group manage-organization-tabs" role="group" aria-label="Manage organization tabs">
         <%= link_to "Users", organization_users_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_users_path(@organization))}" %>
 
-        <%= link_to "Access tokens", organization_allowlisted_jwts_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_allowlisted_jwts_path(@organization))}" %>
+        <% if can? :read, @organization.allowlisted_jwts.build %>
+          <%= link_to "Access tokens", organization_allowlisted_jwts_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_allowlisted_jwts_path(@organization))}" %>
+        <% end %>
 
         <%= link_to "Organization details", organization_details_organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(organization_details_organization_path(@organization))}" %>
 

--- a/app/views/shared/_provider_page_header.html.erb
+++ b/app/views/shared/_provider_page_header.html.erb
@@ -4,10 +4,8 @@
 
         <%= link_to "Normalized data", normalized_data_organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(normalized_data_organization_path(@organization))}" %>
 
-        <% if can? :update, @organization.default_stream %>
-            <%= link_to "Processing status", processing_status_organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(processing_status_organization_path(@organization))}" %>
-        <% end %>
-       
+        <%= link_to "Processing status", processing_status_organization_path(@organization), class: "btn btn-outline-primary #{current_page_class(processing_status_organization_path(@organization))}" %>
+
         <%= link_to "MARC analysis", profile_organization_stream_path(@organization, @organization.default_stream), class: "btn btn-outline-primary #{current_page_class(profile_organization_stream_path(@organization, @organization.default_stream))}" %>
     </div>
 </div>

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Ability do
       # Non-member organization
       it { is_expected.to be_able_to(:read, not_my_org) }
       it { is_expected.to be_able_to(:normalized_data, not_my_org) }
-      it { is_expected.not_to be_able_to(:processing_status, not_my_org) }
+      it { is_expected.to be_able_to(:processing_status, not_my_org) }
       it { is_expected.to be_able_to(:users, not_my_org) }
       it { is_expected.to be_able_to(:organization_details, not_my_org) }
       it { is_expected.to be_able_to(:provider_details, not_my_org) }
@@ -132,7 +132,7 @@ RSpec.describe Ability do
       # Member organization
       it { is_expected.to be_able_to(:read, organization) }
       it { is_expected.to be_able_to(:normalized_data, organization) }
-      it { is_expected.not_to be_able_to(:processing_status, organization) }
+      it { is_expected.to be_able_to(:processing_status, organization) }
       it { is_expected.to be_able_to(:users, organization) }
       it { is_expected.to be_able_to(:organization_details, organization) }
       it { is_expected.to be_able_to(:provider_details, organization) }
@@ -151,7 +151,7 @@ RSpec.describe Ability do
       # Non-member organization
       it { is_expected.to be_able_to(:read, not_my_org) }
       it { is_expected.to be_able_to(:normalized_data, not_my_org) }
-      it { is_expected.not_to be_able_to(:processing_status, not_my_org) }
+      it { is_expected.to be_able_to(:processing_status, not_my_org) }
       it { is_expected.to be_able_to(:users, not_my_org) }
       it { is_expected.to be_able_to(:organization_details, not_my_org) }
       it { is_expected.to be_able_to(:provider_details, not_my_org) }

--- a/spec/views/shared/provider_page_header.html.erb_spec.rb
+++ b/spec/views/shared/provider_page_header.html.erb_spec.rb
@@ -17,13 +17,7 @@ RSpec.describe 'shared/_provider_page_header', type: :view do
     expect(rendered).to have_link('Uploaded files')
     expect(rendered).to have_link('Normalized data')
     expect(rendered).to have_link('MARC analysis')
-  end
-  # rubocop:enable RSpec/MultipleExpectations
-
-  it 'displays the Processing status link for priveleged users' do
-    allow(view).to receive(:can?).and_return(true)
-    render
-
     expect(rendered).to have_link('Processing status')
   end
+  # rubocop:enable RSpec/MultipleExpectations
 end


### PR DESCRIPTION
Closes #640

I opted to allow a user with any role to view processing status for now. Can review decision as part of #634 