### PR TITLE
Visual design updates

### DIFF
--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -38,7 +38,7 @@
 }
 
 .manage-organization-tabs {
-  margin: ($spacer * 3) 0;
+  margin: $spacer 0 ($spacer * 3);
 
   a {
     &.current {

--- a/app/assets/stylesheets/pod-icons.scss
+++ b/app/assets/stylesheets/pod-icons.scss
@@ -2,8 +2,8 @@
 @import 'bootstrap';
 
 .pod-icon > svg, .pod-metadata-status > svg {
-  height: 25px;
-  width: 25px;
+  height: 20px;
+  width: 20px;
 }
 
 .pod-job-tracker-status {

--- a/app/views/allowlisted_jwts/index.html.erb
+++ b/app/views/allowlisted_jwts/index.html.erb
@@ -3,7 +3,7 @@
 <div class="container manage-organization-container">
     <%= render 'shared/manage_organization_header' %>
 
-    <h2>Access tokens</h2>
+    <h3>Access tokens</h3>
 
   <table class="table mt-4">
     <thead>

--- a/app/views/dashboard/uploads.html.erb
+++ b/app/views/dashboard/uploads.html.erb
@@ -1,6 +1,6 @@
 <div class="container index-page">
   <h1 class="mb-4"><%= t('.title') %></h1>
-  <ul class="table-key list-unstyled list-inline pt-2">
+  <ul class="table-key list-unstyled list-inline pt-3">
     <% Settings.metadata_status.each do |status, values| %>
     <li class="list-inline-item">
       <%= bootstrap_icon(values.icon_class, class: "pod-metadata-status #{status}") %>

--- a/app/views/organization_users/index.html.erb
+++ b/app/views/organization_users/index.html.erb
@@ -1,8 +1,8 @@
 <%= render 'shared/organization_header' %>
 <div class="container manage-organization-container">
     <%= render 'shared/manage_organization_header' %>
-    <h2><%= t('.title') %></h2>
-    <%= link_to t('.invite_user'), organization_invite_new_path(@organization), class: 'btn btn-sm btn-primary' if can? :manage, @organization %>
+    <h3><%= t('.title') %></h3>
+    <%= link_to t('.invite_user'), organization_invite_new_path(@organization), class: 'btn btn-sm btn-primary mt-3' if can? :manage, @organization %>
     <table class="table table-striped organizations mt-4">
         <thead>
             <tr>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -2,9 +2,8 @@
   <h1 class="visually-hidden"">Provider statistics</h1>
   <h2>Aggregated uploads from providers</h2>
 
-
   <% unless params[:page] %>
-    <div class="row mb-5">
+    <div class="row mb-5 mt-4">
       <div class="col">
         <h2 class="text-center h6">Files</h2>
         <%= line_chart uploads_chart_path %>
@@ -15,8 +14,6 @@
       </div>
     </div>
   <% end %>
-
-
 
   <h2>Upload statistics by provider</h2>
   

--- a/app/views/organizations/normalized_data.html.erb
+++ b/app/views/organizations/normalized_data.html.erb
@@ -4,7 +4,7 @@
   <%= render 'streams/header', stream: @organization.default_stream %>
   <%= render 'shared/provider_page_header'%>
 
-  <h2>Normalized data</h2>
+  <h3>Normalized data</h3>
 
   <%= render 'streams/normalized_dump', normalized_dump: @organization.default_stream.normalized_dumps.full_dumps.last %>
 </div>

--- a/app/views/organizations/organization_details.html.erb
+++ b/app/views/organizations/organization_details.html.erb
@@ -3,7 +3,7 @@
 <div class="container manage-organization-container">
     <%= render 'shared/manage_organization_header' %>
 
-    <h2>Organization details</h2>
+    <h3>Organization details</h3>
 
     <!-- Admin/owner view: -->
     <% if can? :manage, @organization %>

--- a/app/views/organizations/processing_status.html.erb
+++ b/app/views/organizations/processing_status.html.erb
@@ -4,7 +4,7 @@
   <%= render 'streams/header', stream: @organization.default_stream %>
   <%= render 'shared/provider_page_header'%>
 
-  <h2><%= t('job_tracker.title') %></h2>
+  <h3><%= t('job_tracker.title') %></h3>
 
   <%= render 'streams/job_status', stream: @organization.default_stream if can? :update, @organization.default_stream %>
 

--- a/app/views/organizations/provider_details.html.erb
+++ b/app/views/organizations/provider_details.html.erb
@@ -3,13 +3,13 @@
 <div class="container manage-organization-container">
     <%= render 'shared/manage_organization_header' %>
 
-    <h2>Provider details</h2>
+    <h3>Provider details</h3>
 
     <!-- Admin/owner view: -->
     <% if can? :manage, @organization %>
         <%= bootstrap_form_with(model: @organization, local: true) do |form| %>
             <% if @organization.persisted? %>
-                <h3>Item information</h3>
+                <h4 class="mt-4">Item information</h4>
                 <%= form.hidden_field 'normalization_steps[0][destination_tag]', maxlength: 3, value: @organization.normalization_steps.values.dig(0, 'destination_tag') || 998 %>
                 <%= form.text_field 'normalization_steps[0][source_tag]', maxlength: 3, value: @organization.normalization_steps.values.dig(0, 'source_tag'), label: 'What MARC field contains item-level information?' %>
                 <%= form.text_field 'normalization_steps[0][subfields][i]', maxlength: 1, value: @organization.normalization_steps.values.dig(0, 'subfields', 'i'), label: 'Local identifier subfield' %>
@@ -24,7 +24,7 @@
 
     <!-- Member view: -->
     <% else %>
-    <dl class="organization-details">
+    <dl class="organization-details mt-4">
         <dt>
             <h4>What MARC field contains item-level information?</h4>
             <p class="<%= @organization.normalization_steps.values.dig(0, 'source_tag').blank? ? 'fst-italic' : '' %>">

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -4,7 +4,7 @@
   <%= render 'streams/header', stream: @organization.default_stream %>
   <%= render 'shared/provider_page_header'%>
 
-  <h2>Stream files</h2>
+  <h3>Stream files</h3>
   
   <%= render 'streams/stream_uploads', stream: @organization.default_stream, uploads: @uploads %>
 

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -4,7 +4,7 @@
   <%= render 'streams/header', stream: @organization.default_stream %>
   <%= render 'shared/provider_page_header'%>
 
-  <h3>Stream files</h3>
+  <h3>Uploaded files</h3>
   
   <%= render 'streams/stream_uploads', stream: @organization.default_stream, uploads: @uploads %>
 

--- a/app/views/pages/data.html.erb
+++ b/app/views/pages/data.html.erb
@@ -1,34 +1,27 @@
 <div class="container index-page">
-  <div>
-    <h2><%= t('.guidelines.header') %></h2>
+  <h2><%= t('.guidelines.header') %></h2>
+  <p><%= t('.guidelines.body_html') %></p>
 
-    <p><%= t('.guidelines.body_html') %></p>
-  </div>
-
-  <div>
+  <ul>
     <% t('.guidelines.list_items').each do |item| %>
       <li><%= sanitize item %></li>
     <% end %>
-  </div>
+  </ul>
 
-  <div>
-    <h2><%= t('.harvesting.header') %></h2>
-    <p><%= t('.harvesting.body_html') %></p>
-  </div>
+  <h2><%= t('.harvesting.header') %></h2>
+  <p><%= t('.harvesting.body_html') %></p>
 
-  <div>
-    <h3><%= t('.resource_sync.header') %></h3>
-    <p><%= t('.resource_sync.body_html') %></p>
+  <h3><%= t('.resource_sync.header') %></h3>
+  <p><%= t('.resource_sync.body_html') %></p>
 
-    <div class="card w-50 my-5">
-        <div class="card-header d-flex justify-content-between">
-          <h2 class="h6"><%= t('.resource_sync.sitemaps') %></h2>
-        </div>
-        <ul class="list-group list-group-flush">
-          <li class="list-group-item"><%= link_to t('.resource_sync.original_uploads'), resourcelist_organizations_url %> (real-time)</li>
-          <li class="list-group-item"><%= link_to t('.resource_sync.normalized_marcxml'), normalized_resourcelist_organizations_url(flavor: 'marcxml') %> <%= t('.resource_sync.update_cadence') %></li>
-          <li class="list-group-item"><%= link_to t('.resource_sync.normalized_marc21'), normalized_resourcelist_organizations_url(flavor: 'marc21') %> <%= t('.resource_sync.update_cadence') %></li>
-        </ul>
-    </div>
+  <div class="card w-50 my-4">
+      <div class="card-header d-flex justify-content-between">
+        <h2 class="h6"><%= t('.resource_sync.sitemaps') %></h2>
+      </div>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item"><%= link_to t('.resource_sync.original_uploads'), resourcelist_organizations_url %> (real-time)</li>
+        <li class="list-group-item"><%= link_to t('.resource_sync.normalized_marcxml'), normalized_resourcelist_organizations_url(flavor: 'marcxml') %> <%= t('.resource_sync.update_cadence') %></li>
+        <li class="list-group-item"><%= link_to t('.resource_sync.normalized_marc21'), normalized_resourcelist_organizations_url(flavor: 'marc21') %> <%= t('.resource_sync.update_cadence') %></li>
+      </ul>
   </div>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -120,14 +120,14 @@
   </div>
   <% else %>
   <!-- login section -->
-  <div class="p-3 p-md-5 text-center">
+  <div class="p-3 p-md-5 pb-1 pb-md-4 text-center">
     <% unless current_user %>
-    <h2>
+    <h2 class="h3">
       <%= t('.login.heading') %>
     </h2>
     <%= link_to t('.login.button'), new_user_session_path, class: 'btn btn-primary mt-2' %>
     <% end %>
-    <h2 class="mt-3 mt-md-5">
+    <h2 class="h3 mt-3 mt-md-5">
       <%= t('.login.contact_heading') %>
     </h2>
     <p class="fs-5">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="bg-light border-top py-3 py-md-4">
+<footer class="bg-light border-top mt-3 py-3 py-md-4">
   <div class="container">
     <div class="row">
       <div class="col-md my-3 my-md-0">

--- a/app/views/shared/_manage_organization_header.html.erb
+++ b/app/views/shared/_manage_organization_header.html.erb
@@ -1,11 +1,11 @@
 <div class="d-flex flex-row">
-    <h1>
+    <h2>
         <% if can? :edit, @organization %>
             <%= 'Manage organization'%>
         <% else %>
             <%='View organization' %>
         <% end %>
-    </h1>
+    </h2>
 </div>
 <div class="d-flex flex-row justify-content-center">
     <div class="btn-group manage-organization-tabs" role="group" aria-label="Manage organization tabs">

--- a/app/views/shared/_organization_header.html.erb
+++ b/app/views/shared/_organization_header.html.erb
@@ -1,9 +1,9 @@
 <% content_for :org_header do %>
-  <div class="position-relative overflow-hidden mb-5 pb-2 pt-4 bg-light organization border-bottom">
+  <div class="position-relative overflow-hidden mb-4 pb-2 pt-4 bg-light organization border-bottom">
     <div class="container">
       <div class="d-flex">
 
-        <h1 class="display-5 font-weight-normal p-2">
+        <h1 class="display-5 font-weight-normal p-2 pe-4">
           <% if @organization.icon.attached? %>
             <%= image_tag(@organization.icon, class: 'organization-icon') %>
           <% end %>

--- a/app/views/streams/_header.html.erb
+++ b/app/views/streams/_header.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex align-items-center">
-  <h2 class="font-weight-normal mb-0">Name: <%= stream.display_name %></h2>
+  <h2 class="font-weight-normal mb-0">Stream: <%= stream.display_name %></h2>
 
   <div class="p-2">
     <%= content_tag :span, 'Default', class: 'badge bg-info me-3' if stream.default? %>

--- a/app/views/streams/_stream_uploads.html.erb
+++ b/app/views/streams/_stream_uploads.html.erb
@@ -1,4 +1,4 @@
-<ul class="table-key list-unstyled list-inline pt-2">
+<ul class="table-key list-unstyled list-inline pt-3">
   <% Settings.metadata_status.each do |status, values| %>
     <li class="list-inline-item">
       <%= bootstrap_icon(values.icon_class, class: "pod-metadata-status #{status}") %>

--- a/app/views/streams/_summary_card.html.erb
+++ b/app/views/streams/_summary_card.html.erb
@@ -1,4 +1,4 @@
-<div class="card col-md-4 offset-md-4">
+<div class="card col-12 col-md-8 offset-md-2 col-lg-6 offset-lg-3 col-xxl-4 offset-xxl-4 mb-3">
     <div class="card-body bg-light">
         <div class="row">
             <div class="col">

--- a/app/views/streams/index.html.erb
+++ b/app/views/streams/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="container">
   <div class="d-flex justify-content-between">
-    <h1>Streams</h1>
+    <h2>Streams</h2>
     <%= link_to 'Create new stream', new_organization_stream_path(@organization), class: 'btn btn-primary align-self-center' if can? :create, @organization.streams.build %>
   </div>
 

--- a/app/views/streams/profile.html.erb
+++ b/app/views/streams/profile.html.erb
@@ -4,7 +4,7 @@
   <%= render 'streams/header', stream: @organization.default_stream %>
   <%= render 'shared/provider_page_header'%>
 
-  <h3>Stream profile</h3>
+  <h3>MARC analysis</h3>
 
   <% if @stream.marc_profile %>
     <%= render 'marc_profiles/summary', marc_profile: @stream.marc_profile %>

--- a/app/views/streams/profile.html.erb
+++ b/app/views/streams/profile.html.erb
@@ -4,7 +4,7 @@
   <%= render 'streams/header', stream: @organization.default_stream %>
   <%= render 'shared/provider_page_header'%>
 
-  <h2>Stream profile</h2>
+  <h3>Stream profile</h3>
 
   <% if @stream.marc_profile %>
     <%= render 'marc_profiles/summary', marc_profile: @stream.marc_profile %>

--- a/spec/views/organizations/show.html.erb_spec.rb
+++ b/spec/views/organizations/show.html.erb_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe 'organizations/show', type: :view do
     sign_in create(:admin)
   end
 
-  it 'renders attributes in <p>' do
+  it 'renders the stream name' do
     render
-    expect(rendered).to match(/Name/).and(match(/Slug/))
+    expect(rendered).to match(/stream1/)
   end
 end


### PR DESCRIPTION
I've made a range of visual design updates, mostly pretty minor, involving vertical spacing, headings levels for proper hierarchy, renaming a few heading labels, and reducing the size of the icons.

This is sort of an interim step to try to make things look a bit tidier for today's demo, but there will be more adjustments before the end of the workcycle, especially because my local environment doesn't have much data so I didn't have a realistic view of some pages. I'll see how things look on -prod and adjust from there.