### PR TITLE
Harmonize table styles

### DIFF
--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -9,7 +9,7 @@
 // Table of all organizations
 .organizations {
   .icon-column {
-    min-width: 68px; // Try to avoid some layout shifting when icons are rendered
+    min-width: 35px; // Try to avoid some layout shifting when icons are rendered
   }
 
   .files-column {

--- a/app/views/marc_profiles/_fields.html.erb
+++ b/app/views/marc_profiles/_fields.html.erb
@@ -15,7 +15,7 @@
             <% value, id = values.first %>
             <span class="text-monospace"><%= value %> [<%= id %>]</span>
           <% else %>
-            <button class="btn p-0 m-0 border-0 align-top text-left text-monospace" type="button" data-bs-toggle="collapse" data-bs-target="#profile-<%= field %>" aria-expanded="false" aria-controls="collapseExample">
+            <button class="btn p-0 m-0 border-0 align-top text-start text-monospace" type="button" data-bs-toggle="collapse" data-bs-target="#profile-<%= field %>" aria-expanded="false" aria-controls="collapseExample">
               <% value, id = values.first %>
               <%= value %> [<%= id %>]
               <%= inline_svg_tag 'bootstrap-icons/icons/chevron-right.svg', height: 12, width: 12 %>
@@ -56,7 +56,7 @@
             <% if values.uniq { |(value, id)| value }.length <= 3 %>
               <span class="text-monospace"><%= selected_values.map { |(value,id)| value }.join(', ') %> [<%= selected_values.map { |(value,id)| id }.compact.join(', ') %>]</span>
             <% else %>
-              <button class="btn p-0 m-0 border-0 align-top text-left text-monospace" type="button" data-bs-toggle="collapse" data-bs-target="#profile-<%= field.parameterize %>" aria-expanded="false" aria-controls="collapseExample">
+              <button class="btn p-0 m-0 border-0 align-top text-start text-monospace" type="button" data-bs-toggle="collapse" data-bs-target="#profile-<%= field.parameterize %>" aria-expanded="false" aria-controls="collapseExample">
                 <%= selected_values.map { |(value,id)| value }.join(', ').truncate(100) %> [<%= selected_values.map { |(value,id)| id }.compact.join(', ') %>]
                 <%= inline_svg_tag 'bootstrap-icons/icons/chevron-right.svg', height: 12, width: 12 %>
               </button>

--- a/app/views/marc_profiles/_histogram.html.erb
+++ b/app/views/marc_profiles/_histogram.html.erb
@@ -3,7 +3,7 @@
   <thead>
     <tr>
       <th>Field</th>
-      <th class="text-right">%</th>
+      <th class="text-end">%</th>
       <th class=""></th>
       <th class="text-center">Subfields</th>
     </tr>
@@ -14,7 +14,7 @@
     <% field, *subfields = field_group %>
       <tr class="<%= MarcRules.common_field?(field.first) ? cycle('bg-light', '') : 'bg-local-practice' %>">
         <td class="font-weight-bold"><%= field.first %></td>
-        <td class="text-right"><%= number_to_percentage(100.0 * field.last / marc_profile.count, precision: 2) %></td>
+        <td class="text-end"><%= number_to_percentage(100.0 * field.last / marc_profile.count, precision: 2) %></td>
         <td>
           <% marc_profile.histogram_frequency[field.first].sort_by { |k, _v| k.to_i }.group_by { |k, v| Math.log(k.to_i).round }.each do |group, values| %>
             <% if group < 2 %>
@@ -30,7 +30,7 @@
         </td>
         <td class="text-center">
           <% if subfields.any? %>
-            <button class="btn p-0 m-0 border-0 align-top text-left text-monospace" type="button" data-bs-toggle="collapse" data-bs-target="#histogram-subfields-<%= field.first.parameterize %>" aria-expanded="false" aria-controls="histogram-subfields-<%= field.first.parameterize %>">
+            <button class="btn p-0 m-0 border-0 align-top text-start text-monospace" type="button" data-bs-toggle="collapse" data-bs-target="#histogram-subfields-<%= field.first.parameterize %>" aria-expanded="false" aria-controls="histogram-subfields-<%= field.first.parameterize %>">
               <span class="visually-hidden">Expand</span>
               <%= inline_svg_tag 'bootstrap-icons/icons/chevron-right.svg', height: 20, width: 20 %>
             </button>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -33,23 +33,23 @@
     <tbody>
       <% @organizations.each do |organization| %>
         <tr>
-          <td class="text-center icon-column">
+          <td class="align-middle text-center icon-column">
             <% if organization.icon.attached? %>
               <%= image_tag(organization.icon, class: 'icon-sm') %>
             <% end %>
           </td>
-          <td>
+          <td class="align-middle">
             <%= link_to organization.name, organization %>
           </td>
-          <td class="text-end files-column"><%= organization.default_stream.files.size %></td>
-          <td class="text-end"><%= number_to_human_size organization.default_stream.files.sum(:byte_size) %></td>
-          <td class="text-end"><%= number_with_delimiter organization.latest_statistics.unique_record_count %></td>
-          <td class="text-end"><%= number_with_delimiter organization.latest_statistics.record_count %></td>
-          <td><%= organization.default_stream.uploads.last&.updated_at %></td>
+          <td class="align-middle text-end files-column"><%= organization.default_stream.files.size %></td>
+          <td class="align-middle text-end"><%= number_to_human_size organization.default_stream.files.sum(:byte_size) %></td>
+          <td class="align-middle text-end"><%= number_with_delimiter organization.latest_statistics.unique_record_count %></td>
+          <td class="align-middle text-end"><%= number_with_delimiter organization.latest_statistics.record_count %></td>
+          <td class="align-middle"><%= organization.default_stream.uploads.last&.updated_at %></td>
 
           <% if can? :manage, Organization %>
-            <td><%= link_to 'Edit', organization_details_organization_path(organization), class: 'btn btn-secondary btn-sm' if can? :edit, organization %></td>
-            <td><%= link_to 'Destroy', organization, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' if can? :delete, organization %></td>
+            <td class="align-middle"><%= link_to 'Edit', organization_details_organization_path(organization), class: 'btn btn-secondary btn-sm' if can? :edit, organization %></td>
+            <td class="align-middle"><%= link_to 'Destroy', organization, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' if can? :delete, organization %></td>
           <% end %>
      
         </tr>

--- a/app/views/streams/_dump_attachment.html.erb
+++ b/app/views/streams/_dump_attachment.html.erb
@@ -4,6 +4,6 @@
     <td class="pl-4"><%= link_to_if can?(:read, stream), attachment.filename, download_url(attachment) %></td>
     <td><%= l(attachment.created_at, format: :short) %></td>
     <td><%= number_to_human_size attachment.byte_size %></td>
-    <td class="pr-4 text-right"><%= attachment.metadata['count'] ? number_with_delimiter(attachment.metadata['count']) : '???' %></td>
+    <td class="pr-4 text-end"><%= attachment.metadata['count'] ? number_with_delimiter(attachment.metadata['count']) : '???' %></td>
   </tr>
 <% end %>

--- a/app/views/streams/_normalized_dump.html.erb
+++ b/app/views/streams/_normalized_dump.html.erb
@@ -5,7 +5,7 @@
     </div>
 
     <table class="table table-striped mb-0">
-      <thead><th></th><th class="pl-4">File</th><th>Date created</th><th>Size</th><th class="text-right pr-4">Records</th></thead>
+      <thead><th></th><th class="pl-4">File</th><th>Date created</th><th>Size</th><th class="text-end pr-4">Records</th></thead>
       <tbody>
         <%= render partial: 'streams/dump_attachment', locals: { type: 'Full', attachment: normalized_dump.marc21.attachment, stream: normalized_dump.stream } %>
         <%= render partial: 'streams/dump_attachment', locals: { type: 'Full', attachment: normalized_dump.marcxml.attachment, stream: normalized_dump.stream } %>

--- a/app/views/streams/_stream_uploads.html.erb
+++ b/app/views/streams/_stream_uploads.html.erb
@@ -1,16 +1,24 @@
 <ul class="table-key list-unstyled list-inline pt-3">
   <% Settings.metadata_status.each do |status, values| %>
-    <li class="list-inline-item">
-      <%= bootstrap_icon(values.icon_class, class: "pod-metadata-status #{status}") %>
-      <span class="fw-bold"><%= values.label %></span>
-    </li>
+  <li class="list-inline-item">
+    <%= bootstrap_icon(values.icon_class, class: "pod-metadata-status #{status}") %>
+    <span class="fw-bold"><%= values.label %></span>
+  </li>
   <% end %>
 </ul>
 <table class="table table-striped mb-3">
-  <thead><th>Status</th><th>File</th><th>Date created</th><th class="text-right">Size</th><th>Content type</th><th class="text-right">Records</th><th><span class="visually-hidden">Actions</span></th></thead>
+  <thead>
+    <th class="text-center">Status</th>
+    <th>File</th>
+    <th>Date created</th>
+    <th class="text-end">Size</th>
+    <th>Content type</th>
+    <th class="text-end">Records</th>
+    <th><span class="visually-hidden">Actions</span></th>
+  </thead>
   <tbody>
     <% uploads.each do |upload| %>
-      <%= render 'uploads/file_rows', upload: upload %>
+    <%= render 'uploads/file_rows', upload: upload %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/streams/index.html.erb
+++ b/app/views/streams/index.html.erb
@@ -12,8 +12,8 @@
         <th></th>
         <th>Name</th>
         <th>Last updated</th>
-        <th>File count</th>
-        <th>Default?</th>
+        <th class="text-end">Files</th>
+        <th class="text-end">Size</th>
         <th></th>
         <th></th>
       </tr>
@@ -21,19 +21,19 @@
 
     <tbody>
       <% @streams.active.each do |stream| %>
-        <tr>
-          <td><%= content_tag :span, 'default', class: 'badge bg-info' if stream.default? %></td>
-          <td><%= link_to stream.display_name, organization_stream_path(@organization, stream) %></td>
-          <td><%= stream.updated_at %></td>
-          <td><%= stream.files.size %> | <%= number_to_human_size stream.files.sum(:byte_size) %></td>
-          <td><%= stream.default %></td>
-          <td>
-            <%= link_to 'Destroy', [@organization, stream], method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' if can? :delete, stream %>
-          </td>
-          <td>
-            <%= link_to 'Make default', make_default_organization_streams_path(@organization, stream: stream.slug), method: :post, class: 'btn btn-info' if !stream.default? && can?(:manage, stream) %>
-          </td>
-        </tr>
+      <tr>
+        <td class="align-middle"><%= content_tag :span, 'default', class: 'badge bg-info' if stream.default? %></td>
+        <td class="align-middle"><%= link_to stream.display_name, organization_stream_path(@organization, stream) %></td>
+        <td class="align-middle"><%= stream.updated_at %></td>
+        <td class="align-middle text-end"><%= stream.files.size %></td>
+        <td class="align-middle text-end"><%= number_to_human_size stream.files.sum(:byte_size) %></td>
+        <td class="align-middle">
+          <%= link_to 'Destroy', [@organization, stream], method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-danger' if can? :delete, stream %>
+        </td>
+        <td class="align-middle">
+          <%= link_to 'Make default', make_default_organization_streams_path(@organization, stream: stream.slug), method: :post, class: 'btn btn-sm btn-info' if !stream.default? && can?(:manage, stream) %>
+        </td>
+      </tr>
       <% end %>
     </tbody>
   </table>

--- a/app/views/uploads/_file_rows.html.erb
+++ b/app/views/uploads/_file_rows.html.erb
@@ -5,34 +5,33 @@
       <i>Downloading...</i>
     </td>
     <td><%= l(upload.created_at, format: :short) %></td>
-    <td class="text-right">-</td>
+    <td class="text-end">-</td>
     <td>-</td>
-    <td class="text-right">-</td>
+    <td class="text-end">-</td>
     <td><%= link_to 'Source 🔗', upload.url, title: upload.url %></td>
   </tr>
 <% end %>
 <% upload.files.each do |file| %>
   <tr>
-    <td class="text-center">
+    <td class="align-middle text-center">
       <%= bootstrap_icon(Settings.metadata_status[file.pod_metadata_status].icon_class, class: "pod-metadata-status #{file.pod_metadata_status}") %>
       <span class="visually-hidden"><%= file.pod_metadata_status %></span>
     </td> 
-    <td>
+    <td class="align-middle">
       <%= link_to_if can?(:read, upload), file.filename, download_url(file), title: "Download #{file.filename}" %>
     </td>
-    <td><%= l(file.created_at, format: :short) %></td>
-    <td class="text-right"><%= number_to_human_size file.byte_size %></td>
-    <td><%= file.content_type %></td>
-    <td class="text-right"><%= file.metadata['count'] ? number_with_delimiter(file.metadata['count']) : '-' %></td>
-
-    <td>
+    <td class="align-middle"><%= l(file.created_at, format: :short) %></td>
+    <td class="align-middle text-end"><%= number_to_human_size file.byte_size %></td>
+    <td class="align-middle"><%= file.content_type %></td>
+    <td class="align-middle text-end"><%= file.metadata['count'] ? number_with_delimiter(file.metadata['count']) : '-' %></td>
+    <td class="align-middle text-center">
       <% if can? :read, upload %>
-        <%= link_to file_info_organization_upload_path(@organization, upload, file), class: 'btn btn-secondary' do %>
+        <%= link_to file_info_organization_upload_path(@organization, upload, file), class: 'btn btn-sm btn-secondary' do %>
           <%= bootstrap_icon("search", class: "pod-icon") %>
           <span class="visually-hidden">Profile</span>
         <% end %>
         <% if upload.url.present? %>
-          <%= link_to 'Source 🔗', upload.url, title: upload.url, class: 'btn btn-link' %>
+          <%= link_to 'Source 🔗', upload.url, title: upload.url, class: 'btn btn-sm btn-link' %>
         <% end %>
       <% end %>
     </td>

--- a/app/views/uploads/show.html.erb
+++ b/app/views/uploads/show.html.erb
@@ -18,7 +18,7 @@
   <h2>Files</h2>
 
   <table class="table table-striped mb-0 mt-4">
-    <thead><th class="pl-4">File</th><th>Date created</th><th class="text-right">Size</th><th>Content type</th><th class="text-right">Records</th><th>File status</th></thead>
+    <thead><th class="pl-4">File</th><th>Date created</th><th class="text-end">Size</th><th>Content type</th><th class="text-end">Records</th><th>File status</th></thead>
     <tbody>
       <%= render 'uploads/file_rows', upload: @upload %>
     </tbody>


### PR DESCRIPTION
this PR makes a small number of changes to table displays so that they're more consistent.

* uses `align-middle` so that table cell contents are always vertically centered
* replaces `text-left` and `text-right` with BS5 `text-start` and `text-end` so that text is correctly aligned
* tries to better align a few table headers with their content
* makes buttons inside table rows all `.btn-sm` so they impact layout less and are consistent