### PR TITLE
Revert changes to token ability settings.

### DIFF
--- a/app/controllers/allowlisted_jwts_controller.rb
+++ b/app/controllers/allowlisted_jwts_controller.rb
@@ -4,7 +4,6 @@
 class AllowlistedJwtsController < ApplicationController
   load_and_authorize_resource :organization
   load_and_authorize_resource through: :organization
-  authorize_resource class: :controller
 
   # GET /organizations/1/allowlisted_jwts
   # GET /organizations/1/allowlisted_jwts.json

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -59,7 +59,6 @@ class Ability
     can %i[crud profile info], [Stream, Upload], organization: { id: owned_orgs }
     can :read, MarcRecord, upload: { organization: { id: owned_orgs } }
     can :manage, AllowlistedJwt, resource_type: 'Organization', resource_id: owned_orgs
-    can :manage, :allowlisted_jwts_controller, resource_type: 'Organization', resource_id: owned_orgs
     can :read, ActiveStorage::Attachment, { record: { organization: { id: owned_orgs } } }
 
     member_orgs = Organization.with_role(:member, user).pluck(:id)
@@ -67,6 +66,7 @@ class Ability
     can %i[read profile info], [Stream, Upload], organization: { id: member_orgs }
     can %i[create], [Upload], organization: { id: member_orgs }
     can :read, MarcRecord, upload: { organization: { id: member_orgs } }
+    can :read, AllowlistedJwt, resource_type: 'Organization', resource_id: member_orgs
     can :read, ActiveStorage::Attachment, { record: { organization: { id: member_orgs } } }
   end
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Ability do
       it { is_expected.not_to be_able_to(:create, Stream.new(organization: organization)) }
       it { is_expected.not_to be_able_to(:reanalyze, Stream.new(organization: organization)) }
 
-      it { is_expected.not_to be_able_to(:read, AllowlistedJwt.new(resource: organization)) }
+      it { is_expected.to be_able_to(:read, AllowlistedJwt.new(resource: organization)) }
       it { is_expected.not_to be_able_to(:create, AllowlistedJwt.new(resource: organization)) }
 
       # Non-member organization


### PR DESCRIPTION
The change is causing org owners not to be able to access their tokens.