### PR TITLE
Calculate interstream deltas

### DIFF
--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+##
+# Background job to generate interstream delta between a stream and its predecessor
+class GenerateInterstreamDeltaJob < ApplicationJob
+	with_job_tracking
+  
+	def self.generate_interstream_delta_for_stream(stream)
+		if (stream.is_a? Integer)
+			stream = Stream.find(stream)
+		end
+		# default_stream_histories = stream.organization.default_stream_histories.all.count
+		GenerateInterstreamDeltaJob.perform_later(stream)
+	end
+  
+	# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+	def perform(stream)
+		current_stream_history = stream.default_stream_history
+		previous_stream_history = current_stream_history.previous_stream_history
+	end
+  end
+  

--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -15,7 +15,10 @@ class GenerateInterstreamDeltaJob < ApplicationJob
   
 	# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 	def perform(stream)
-		previous_stream = stream.default_stream_history.previous_stream_history.stream
+		previous_stream_history = stream.default_stream_history.previous_stream_history
+		return if previous_stream_history.nil?
+
+		previous_stream = previous_stream_history.stream
 		return if previous_stream.nil?
 		
 		current_stream_dump = stream.current_full_dump

--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -107,7 +107,7 @@ class GenerateInterstreamDeltaJob < ApplicationJob
     current_stream_dump.interstream_delta.public_send(:marc21).attach(io: File.open(mrc_tempfile), filename: "#{base_name}.mrc")
     current_stream_dump.interstream_delta.public_send(:marcxml).attach(io: File.open(xml_tempfile), filename: "#{base_name}.xml")
     current_stream_dump.interstream_delta
-      .public_send(:deletes).attach(io: File.open(delete_tempfile), filename: "#{base_name}.del.txt")
+    .public_send(:deletes).attach(io: File.open(delete_tempfile), filename: "#{base_name}.del.txt")
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 end

--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -3,115 +3,115 @@
 ##
 # Background job to generate interstream delta between a stream and its predecessor
 class GenerateInterstreamDeltaJob < ApplicationJob
-	with_job_tracking
+  with_job_tracking
   
-	def self.generate_interstream_delta_for_stream(stream)
-		if (stream.is_a? Integer)
-			stream = Stream.find_by_id(stream)
-		end
-		return if stream.nil?
-		GenerateInterstreamDeltaJob.perform_later(stream)
-	end
+  def self.generate_interstream_delta_for_stream(stream)
+    if (stream.is_a? Integer)
+      stream = Stream.find_by_id(stream)
+    end
+    return if stream.nil?
+    GenerateInterstreamDeltaJob.perform_later(stream)
+  end
   
-	# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-	def perform(stream)
-		previous_stream_history = stream.default_stream_history.previous_stream_history
-		return if previous_stream_history.nil?
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def perform(stream)
+    previous_stream_history = stream.default_stream_history.previous_stream_history
+    return if previous_stream_history.nil?
 
-		previous_stream = previous_stream_history.stream
-		
-		current_stream_dump = stream.current_full_dump
-		previous_stream_dump = previous_stream.current_full_dump
+    previous_stream = previous_stream_history.stream
+    
+    current_stream_dump = stream.current_full_dump
+    previous_stream_dump = previous_stream.current_full_dump
 
-		return unless current_stream_dump && previous_stream_dump
+    return unless current_stream_dump && previous_stream_dump
 
-		# compare full dump of full stream vs previous stream's full dump + its deltas
-		# Get full dump and its records
-		comparison_hash = {}
-		updates_and_additions = []
-		previous_stream_reader = MarcRecordService.new(previous_stream_dump.marcxml.blob)
-		previous_stream_reader.each_slice(100) do |batch|
-			batch.each do |record|
-				comparison_hash[record['001'].value] = record
-			end
-		end
+    # compare full dump of full stream vs previous stream's full dump + its deltas
+    # Get full dump and its records
+    comparison_hash = {}
+    updates_and_additions = []
+    previous_stream_reader = MarcRecordService.new(previous_stream_dump.marcxml.blob)
+    previous_stream_reader.each_slice(100) do |batch|
+      batch.each do |record|
+        comparison_hash[record['001'].value] = record
+      end
+    end
 
-		# Then one-by-one adjust according to each delta from oldest to newest
-		previous_stream_deltas = previous_stream_dump.deltas.order(created_at: :asc)
-		previous_stream_deltas.each do |delta|
-			if delta.marcxml.blob
-				delta_reader = MarcRecordService.new(delta.marcxml.blob)
-				delta_reader.each_slice(100) do |batch|
-					batch.each do |record|
-						comparison_hash[record['001'].value] = record
-					end
-				end
-			end
-			if delta.deletes.blob
-				delta.deletes.blob.open do |tempfile|
-					delete_ids = tempfile.read.split
-					delete_ids.each do |delete_id|
-						if comparison_hash.key?(delete_id)
-							comparison_hash.delete(delete_id)
-						end
-					end
-				end
-			end
-		end
+    # Then one-by-one adjust according to each delta from oldest to newest
+    previous_stream_deltas = previous_stream_dump.deltas.order(created_at: :asc)
+    previous_stream_deltas.each do |delta|
+      if delta.marcxml.blob
+        delta_reader = MarcRecordService.new(delta.marcxml.blob)
+        delta_reader.each_slice(100) do |batch|
+          batch.each do |record|
+            comparison_hash[record['001'].value] = record
+          end
+        end
+      end
+      if delta.deletes.blob
+        delta.deletes.blob.open do |tempfile|
+          delete_ids = tempfile.read.split
+          delete_ids.each do |delete_id|
+            if comparison_hash.key?(delete_id)
+              comparison_hash.delete(delete_id)
+            end
+          end
+        end
+      end
+    end
 
-		current_stream_reader = MarcRecordService.new(current_stream_dump.marcxml.blob)
-		records_in_second_dump = 0
-		current_stream_reader.each_slice(100) do |batch|
-			batch.each do |record|
-				records_in_second_dump = records_in_second_dump + 1
-				if comparison_hash.key?(record['001'].value) && comparison_hash[record['001'].value] == record
-					# Matching record that has not been updated
-					# per the code in the marc record class: https://github.com/ruby-marc/ruby-marc/blob/master/lib/marc/record.rb
-					# == appears to be a safe way to compare MARC::Record objects
-					comparison_hash.delete(record['001'].value)
-					Rails.logger.info("Found an identifcal record in both dumps: delete from hash")
-				elsif comparison_hash.key?(record['001'].value)
-					# Matching records that have been updated, are added to updates_and_additions and removed from comparison
-					updates_and_additions << record
-					comparison_hash.delete(record['001'].value)
-					Rails.logger.info("Found an updated record in new dump: new addition")
-				else
-					# New records are added to updates_and_additions
-					updates_and_additions << record
-					Rails.logger.info("Found a record not in comparison hash: new addition")
-				end
-			end
-		end
+    current_stream_reader = MarcRecordService.new(current_stream_dump.marcxml.blob)
+    records_in_second_dump = 0
+    current_stream_reader.each_slice(100) do |batch|
+      batch.each do |record|
+        records_in_second_dump = records_in_second_dump + 1
+        if comparison_hash.key?(record['001'].value) && comparison_hash[record['001'].value] == record
+          # Matching record that has not been updated
+          # per the code in the marc record class: https://github.com/ruby-marc/ruby-marc/blob/master/lib/marc/record.rb
+          # == appears to be a safe way to compare MARC::Record objects
+          comparison_hash.delete(record['001'].value)
+          Rails.logger.info("Found an identifcal record in both dumps: delete from hash")
+        elsif comparison_hash.key?(record['001'].value)
+          # Matching records that have been updated, are added to updates_and_additions and removed from comparison
+          updates_and_additions << record
+          comparison_hash.delete(record['001'].value)
+          Rails.logger.info("Found an updated record in new dump: new addition")
+        else
+          # New records are added to updates_and_additions
+          updates_and_additions << record
+          Rails.logger.info("Found a record not in comparison hash: new addition")
+        end
+      end
+    end
 
-		deletions = comparison_hash.keys
+    deletions = comparison_hash.keys
 
-		# Create Files
-		base_name = "#{stream.organization.slug}_interstreamdelta_#{previous_stream.id}_#{stream.id}".strip
+    # Create Files
+    base_name = "#{stream.organization.slug}_interstreamdelta_#{previous_stream.id}_#{stream.id}".strip
 
-		mrc_tempfile = Tempfile.new("#{base_name}.mrc")
-		writer = MARC::Writer.new(mrc_tempfile)
-		updates_and_additions.each do |record|
-			writer.write(record)
-		end
-		writer.close()
+    mrc_tempfile = Tempfile.new("#{base_name}.mrc")
+    writer = MARC::Writer.new(mrc_tempfile)
+    updates_and_additions.each do |record|
+      writer.write(record)
+    end
+    writer.close()
 
-		xml_tempfile = Tempfile.new("#{base_name}.xml")
-		xml_writer = MARC::XMLWriter.new(xml_tempfile)
-		updates_and_additions.each do |record|
-			xml_writer.write(record)
-		end
-		xml_writer.close()
-		
-		delete_tempfile = Tempfile.new("#{base_name}.del.txt")
-		File.write(delete_tempfile, deletions.join("\n"))
+    xml_tempfile = Tempfile.new("#{base_name}.xml")
+    xml_writer = MARC::XMLWriter.new(xml_tempfile)
+    updates_and_additions.each do |record|
+      xml_writer.write(record)
+    end
+    xml_writer.close()
+    
+    delete_tempfile = Tempfile.new("#{base_name}.del.txt")
+    File.write(delete_tempfile, deletions.join("\n"))
 
-		# Attach Files
-		if !current_stream_dump.interstream_delta
-			current_stream_dump.interstream_delta = InterstreamDelta.create(normalized_dump: current_stream_dump)
-		end
+    # Attach Files
+    if !current_stream_dump.interstream_delta
+      current_stream_dump.interstream_delta = InterstreamDelta.create(normalized_dump: current_stream_dump)
+    end
 
-		current_stream_dump.interstream_delta.public_send(:marc21).attach(io: File.open(mrc_tempfile), filename: "#{base_name}.mrc")
-		current_stream_dump.interstream_delta.public_send(:marcxml).attach(io: File.open(xml_tempfile), filename: "#{base_name}.xml")
-		current_stream_dump.interstream_delta.public_send(:deletes).attach(io: File.open(delete_tempfile), filename: "#{base_name}.del.txt")
-	end
+    current_stream_dump.interstream_delta.public_send(:marc21).attach(io: File.open(mrc_tempfile), filename: "#{base_name}.mrc")
+    current_stream_dump.interstream_delta.public_send(:marcxml).attach(io: File.open(xml_tempfile), filename: "#{base_name}.xml")
+    current_stream_dump.interstream_delta.public_send(:deletes).attach(io: File.open(delete_tempfile), filename: "#{base_name}.del.txt")
+  end
 end

--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -7,16 +7,62 @@ class GenerateInterstreamDeltaJob < ApplicationJob
   
 	def self.generate_interstream_delta_for_stream(stream)
 		if (stream.is_a? Integer)
-			stream = Stream.find(stream)
+			stream = Stream.find_by_id(stream)
 		end
-		# default_stream_histories = stream.organization.default_stream_histories.all.count
+		return if stream.nil?
 		GenerateInterstreamDeltaJob.perform_later(stream)
 	end
   
 	# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 	def perform(stream)
-		current_stream_history = stream.default_stream_history
-		previous_stream_history = current_stream_history.previous_stream_history
+		previous_stream = stream.default_stream_history.previous_stream_history.stream
+		return if previous_stream.nil?
+		
+		current_stream_dump = stream.current_full_dump
+		previous_stream_dump = previous_stream.current_full_dump
+
+		return unless current_stream_dump and previous_stream_dump
+
+		comparison_hash = {}
+		additions = []
+		previous_stream_reader = MarcRecordService.new(previous_stream_dump.marcxml.blob)
+		previous_stream_reader.each_slice(100) do |batch|
+			batch.each do |record|
+				# Rails.logger.info(record.class)
+				# Rails.logger.info(record)
+				# Rails.logger.info(record['001'])
+				# Rails.logger.info(record['001'].value) # This is what I want
+				comparison_hash[record['001'].value] = 'record goes here'
+			end
+		end
+
+		current_stream_reader = MarcRecordService.new(current_stream_dump.marcxml.blob)
+		current_stream_reader.each_slice(100) do |batch|
+			batch.each do |record|
+				if comparison_hash.key?(record['001'].value)
+					comparison_hash.delete(record['001'].value)
+					Rails.logger.info("Found a record in both: delete from hash")
+				else
+					additions << record['001'].value
+					Rails.logger.info("Found a record not in comparison hash: new addition")
+				end
+			end
+		end
+
+		deletions = comparison_hash.values
+
+		#####
+		# first		# second	# to-do
+		# ------------------------------
+		#	yes			yes			nothing
+		#   no			yes			addition
+		#	yes			no			deletion
+
+		Rails.logger.info(comparison_hash.to_yaml)
+		Rails.logger.info('additions')
+		Rails.logger.info(additions)
+		Rails.logger.info('deletions')
+		Rails.logger.info(deletions)
 	end
   end
   

--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -103,7 +103,7 @@ class GenerateInterstreamDeltaJob < ApplicationJob
 
     # Attach Files
     unless current_stream_dump.interstream_delta
-      current_stream_dump.interstream_delta = InterstreamDelta.create(normalized_dump: current_stream_dump)
+      current_stream_dump.interstream_delta = InterstreamDelta.create(normalized_dump: current_stream_dump, stream: stream)
     end
 
     current_stream_dump.interstream_delta.public_send(:marc21).attach(io: File.open(mrc_tempfile), filename: "#{base_name}.mrc")

--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -19,7 +19,6 @@ class GenerateInterstreamDeltaJob < ApplicationJob
 		return if previous_stream_history.nil?
 
 		previous_stream = previous_stream_history.stream
-		return if previous_stream.nil?
 		
 		current_stream_dump = stream.current_full_dump
 		previous_stream_dump = previous_stream.current_full_dump

--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -102,7 +102,7 @@ class GenerateInterstreamDeltaJob < ApplicationJob
     File.write(delete_tempfile, deletions.join("\n"))
 
     # Attach Files
-    if !current_stream_dump.interstream_delta
+    unless current_stream_dump.interstream_delta
       current_stream_dump.interstream_delta = InterstreamDelta.create(normalized_dump: current_stream_dump)
     end
 

--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -51,9 +51,7 @@ class GenerateInterstreamDeltaJob < ApplicationJob
         delta.deletes.blob.open do |tempfile|
           delete_ids = tempfile.read.split
           delete_ids.each do |delete_id|
-            if comparison_hash.key?(delete_id)
-              comparison_hash.delete(delete_id)
-            end
+            comparison_hash.delete(delete_id) if comparison_hash.key?(delete_id)
           end
         end
       end
@@ -108,7 +106,8 @@ class GenerateInterstreamDeltaJob < ApplicationJob
 
     current_stream_dump.interstream_delta.public_send(:marc21).attach(io: File.open(mrc_tempfile), filename: "#{base_name}.mrc")
     current_stream_dump.interstream_delta.public_send(:marcxml).attach(io: File.open(xml_tempfile), filename: "#{base_name}.xml")
-    current_stream_dump.interstream_delta.public_send(:deletes).attach(io: File.open(delete_tempfile), filename: "#{base_name}.del.txt")
+    current_stream_dump.interstream_delta
+      .public_send(:deletes).attach(io: File.open(delete_tempfile), filename: "#{base_name}.del.txt")
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 end

--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -50,6 +50,7 @@ class GenerateInterstreamDeltaJob < ApplicationJob
       if delta.deletes.blob
         delta.deletes.blob.open do |tempfile|
           delete_ids = tempfile.read.split
+          delete_ids.each do |delete_id|
             if comparison_hash.key?(delete_id)
               comparison_hash.delete(delete_id)
             end

--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -4,15 +4,16 @@
 # Background job to generate interstream delta between a stream and its predecessor
 class GenerateInterstreamDeltaJob < ApplicationJob
   with_job_tracking
-  
+
   def self.generate_interstream_delta_for_stream(stream)
     if (stream.is_a? Integer)
-      stream = Stream.find_by_id(stream)
+      stream = Stream.find_by(stream)
     end
     return if stream.nil?
+
     GenerateInterstreamDeltaJob.perform_later(stream)
   end
-  
+
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def perform(stream)
     previous_stream_history = stream.default_stream_history.previous_stream_history
@@ -114,4 +115,5 @@ class GenerateInterstreamDeltaJob < ApplicationJob
     current_stream_dump.interstream_delta.public_send(:marcxml).attach(io: File.open(xml_tempfile), filename: "#{base_name}.xml")
     current_stream_dump.interstream_delta.public_send(:deletes).attach(io: File.open(delete_tempfile), filename: "#{base_name}.del.txt")
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 end

--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -7,7 +7,7 @@ class GenerateInterstreamDeltaJob < ApplicationJob
 
   def self.generate_interstream_delta_for_stream(stream)
     if stream.is_a? Integer
-      stream = Stream.find_by(stream)
+      stream = Stream.find(stream)
     end
     return if stream.nil?
 

--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -106,8 +106,9 @@ class GenerateInterstreamDeltaJob < ApplicationJob
 
     current_stream_dump.interstream_delta.public_send(:marc21).attach(io: File.open(mrc_tempfile), filename: "#{base_name}.mrc")
     current_stream_dump.interstream_delta.public_send(:marcxml).attach(io: File.open(xml_tempfile), filename: "#{base_name}.xml")
-    current_stream_dump.interstream_delta
-    .public_send(:deletes).attach(io: File.open(delete_tempfile), filename: "#{base_name}.del.txt")
+    # rubocop:disable Layout/LineLength
+    current_stream_dump.interstream_delta.public_send(:deletes).attach(io: File.open(delete_tempfile), filename: "#{base_name}.del.txt")
+    # rubocop:enable Layout/LineLength
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 end

--- a/app/models/default_stream_history.rb
+++ b/app/models/default_stream_history.rb
@@ -4,4 +4,11 @@
 class DefaultStreamHistory < ApplicationRecord
   belongs_to :organization
   belongs_to :stream
+
+  def previous_stream_history
+    # Get previous stream history
+    histories = organization.default_stream_histories.all.order(start_time: :desc)
+    index = histories.find_index { |stream_history| stream_history.stream == stream }
+    histories[index + 1]
+  end
 end

--- a/app/models/interstream_delta.rb
+++ b/app/models/interstream_delta.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# :nodoc:
 class InterstreamDelta < ApplicationRecord
   belongs_to :normalized_dump
 

--- a/app/models/interstream_delta.rb
+++ b/app/models/interstream_delta.rb
@@ -1,0 +1,7 @@
+class InterstreamDelta < ApplicationRecord
+  belongs_to :normalized_dump
+
+  has_one_attached :marc21
+  has_one_attached :marcxml
+  has_one_attached :deletes
+end

--- a/app/models/interstream_delta.rb
+++ b/app/models/interstream_delta.rb
@@ -3,6 +3,7 @@
 # :nodoc:
 class InterstreamDelta < ApplicationRecord
   belongs_to :normalized_dump
+  belongs_to :stream
 
   has_one_attached :marc21
   has_one_attached :marcxml

--- a/app/models/normalized_dump.rb
+++ b/app/models/normalized_dump.rb
@@ -13,4 +13,5 @@ class NormalizedDump < ApplicationRecord
   has_one_attached :marcxml
   has_one_attached :deletes
   has_many_attached :errata
+  has_one_attached :interstream_delta_additions
 end

--- a/app/models/normalized_dump.rb
+++ b/app/models/normalized_dump.rb
@@ -8,6 +8,7 @@ class NormalizedDump < ApplicationRecord
   has_one :organization, through: :stream
   has_many :deltas, class_name: 'NormalizedDump', foreign_key: 'full_dump_id', inverse_of: :full_dump, dependent: :destroy
   belongs_to :full_dump, class_name: 'NormalizedDump', optional: true
+  has_one :interstream_delta, dependent: :destroy
 
   has_one_attached :marc21
   has_one_attached :marcxml

--- a/app/models/normalized_dump.rb
+++ b/app/models/normalized_dump.rb
@@ -13,9 +13,4 @@ class NormalizedDump < ApplicationRecord
   has_one_attached :marcxml
   has_one_attached :deletes
   has_many_attached :errata
-
-  # Seems to make sense to attach these to a full-dump, because 
-  # updating a full-dump will mean they need to be recalculated
-  has_one_attached :interstream_delta_additions
-  has_one_attached :interstream_delta_deletions
 end

--- a/app/models/normalized_dump.rb
+++ b/app/models/normalized_dump.rb
@@ -13,5 +13,9 @@ class NormalizedDump < ApplicationRecord
   has_one_attached :marcxml
   has_one_attached :deletes
   has_many_attached :errata
+
+  # Seems to make sense to attach these to a full-dump, because 
+  # updating a full-dump will mean they need to be recalculated
   has_one_attached :interstream_delta_additions
+  has_one_attached :interstream_delta_deletions
 end

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -13,7 +13,6 @@ class Stream < ApplicationRecord
   has_one :statistic, dependent: :delete, as: :resource
   has_many :normalized_dumps, dependent: :destroy
   has_many :job_trackers, dependent: :delete_all, as: :reports_on
-  has_many :interstream_deltas, dependent: :destroy
 
   scope :default, -> { where(default: true) }
   scope :active, -> { where(status: 'active') }

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -7,7 +7,7 @@ class Stream < ApplicationRecord
   friendly_id :name, use: %i[finders slugged scoped], scope: :organization
   belongs_to :organization
   has_many :uploads, dependent: :destroy
-  has_many :default_stream_histories, dependent: :destroy
+  has_one :default_stream_history, dependent: :destroy
   has_many :marc_records, through: :uploads, inverse_of: :stream
   has_many :files, source: :files_blobs, through: :uploads
   has_one :statistic, dependent: :delete, as: :resource

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -13,6 +13,7 @@ class Stream < ApplicationRecord
   has_one :statistic, dependent: :delete, as: :resource
   has_many :normalized_dumps, dependent: :destroy
   has_many :job_trackers, dependent: :delete_all, as: :reports_on
+  has_many :interstream_deltas, dependent: :destroy
 
   scope :default, -> { where(default: true) }
   scope :active, -> { where(status: 'active') }

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym "RESTful"
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+	inflect.irregular 'interstream_delta', 'interstream_deltas'  
+end

--- a/db/migrate/20220427170933_create_interstream_deltas.rb
+++ b/db/migrate/20220427170933_create_interstream_deltas.rb
@@ -1,0 +1,9 @@
+class CreateInterstreamDeltas < ActiveRecord::Migration[7.0]
+  def change
+    create_table :interstream_deltas do |t|
+      t.references :normalized_dump, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220428184100_add_stream_to_interstream_deltas.rb
+++ b/db/migrate/20220428184100_add_stream_to_interstream_deltas.rb
@@ -1,0 +1,5 @@
+class AddStreamToInterstreamDeltas < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :interstream_deltas, :stream, null: false, foreign_key: true
+  end
+end

--- a/spec/factories/interstream_deltas.rb
+++ b/spec/factories/interstream_deltas.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :interstream_delta do
     normalized_dump { nil }

--- a/spec/factories/interstream_deltas.rb
+++ b/spec/factories/interstream_deltas.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :interstream_delta do
+    normalized_dump { nil }
+  end
+end

--- a/spec/factories/upload.rb
+++ b/spec/factories/upload.rb
@@ -37,6 +37,17 @@ FactoryBot.define do
       end
     end
 
+    trait :marc_xml2 do
+      after(:build) do |upload|
+        upload.files.attach(
+          io: File.open(
+            Rails.root.join('spec/fixtures/67890.marcxml')
+          ),
+          filename: '67890.marcxml', content_type: 'application/marcxml+xml'
+        )
+      end
+    end
+
     trait :deleted_binary_marc do
       after(:build) do |upload|
         upload.files.attach(

--- a/spec/fixtures/67890.marcxml
+++ b/spec/fixtures/67890.marcxml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+   <leader>01257nam a2200325   4500</leader>
+   <controlfield tag="001">b23456</controlfield>
+   <controlfield tag="003">FAKE</controlfield>
+   <controlfield tag="005">20200914003002.0</controlfield>
+   <controlfield tag="008">780221s1958    ii f          000 0 eng d</controlfield>
+   <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC-M)3656884</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC-I)268806725</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">AFU</subfield>
+      <subfield code="c">AFU</subfield>
+      <subfield code="d">m/c</subfield>
+      <subfield code="d">STF</subfield>
+      <subfield code="d">OrLoB</subfield>
+   </datafield>
+   <datafield ind1="1" ind2=" " tag="041">
+      <subfield code="a">eng</subfield>
+      <subfield code="h">san</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="049">
+      <subfield code="a">STFA</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="092">
+      <subfield code="a">181.4</subfield>
+      <subfield code="b">Y5W89 ed.6</subfield>
+   </datafield>
+   <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Woodroffe, John George,</subfield>
+      <subfield code="c">Sir,</subfield>
+      <subfield code="d">1865-1936.</subfield>
+      <subfield code=" ">^A34726</subfield>
+   </datafield>
+   <datafield ind1="1" ind2="4" tag="245">
+      <subfield code="a">Some words here:</subfield>
+      <subfield code="b">these are also words,</subfield>
+      <subfield code="b">subfield,</subfield>
+      <subfield code="c">another subfield.</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="250">
+      <subfield code="a">6th ed.</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">FirstName,</subfield>
+      <subfield code="b">LastName,</subfield>
+      <subfield code="c">1950.</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">xiv, 529, v, 184 p.</subfield>
+      <subfield code="b">XVII plates (part col.)</subfield>
+      <subfield code="c">25 cm.</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="596">
+      <subfield code="a">31</subfield>
+   </datafield>
+   <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Yoga.</subfield>
+      <subfield code=" ">^A1076704</subfield>
+   </datafield>
+   <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Shaktism.</subfield>
+      <subfield code=" ">^A1060436</subfield>
+   </datafield>
+   <datafield ind1="0" ind2=" " tag="700">
+      <subfield code="a">Pūrnānanda Gosvāmǐ.</subfield>
+      <subfield code="t">Sat-cakra-nirūpana.</subfield>
+      <subfield code=" ">UNAUTHORIZED</subfield>
+   </datafield>
+   <datafield ind1="0" ind2=" " tag="700">
+      <subfield code="a">Pādukā.</subfield>
+      <subfield code=" ">UNAUTHORIZED</subfield>
+   </datafield>
+   <datafield ind1="0" ind2=" " tag="700">
+      <subfield code="a">Kālīcharana, Tāntrika.</subfield>
+      <subfield code=" ">UNAUTHORIZED</subfield>
+   </datafield>
+   <datafield ind1="0" ind2=" " tag="740">
+      <subfield code="a">Satcakranirūpana.</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="916">
+      <subfield code="a">DATE CATALOGED</subfield>
+      <subfield code="b">19900915</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="919">
+      <subfield code="a">exclude from BorrowDirect</subfield>
+      <subfield code="b">HathiTrust ETAS</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="999">
+      <subfield code="a">181.4 .Y5 W89 ED.6</subfield>
+      <subfield code="w">DEWEY</subfield>
+      <subfield code="c">1</subfield>
+      <subfield code="i">36105010209950</subfield>
+      <subfield code="d">8/9/2019</subfield>
+      <subfield code="e">6/18/2019</subfield>
+      <subfield code="l">STACKS</subfield>
+      <subfield code="m">SAL3</subfield>
+      <subfield code="n">4</subfield>
+      <subfield code="r">Y</subfield>
+      <subfield code="s">Y</subfield>
+      <subfield code="t">STKS-MONO</subfield>
+      <subfield code="u">2/21/1978</subfield>
+   </datafield>
+</record>

--- a/spec/jobs/generate_interstream_delta_job_spec.rb
+++ b/spec/jobs/generate_interstream_delta_job_spec.rb
@@ -17,6 +17,40 @@ RSpec.describe GenerateInterstreamDeltaJob, type: :job do
 		expect(organization.default_stream.current_full_dump.interstream_delta).to be(nil)
 	end
 
-	# test for no result on no existing dump for previous stream
-	# test for no result on no existing dump for current stream
+	it 'Does not create an interstream delta if the current stream is missing a full dump' do
+		GenerateFullDumpJob.perform_now(organization)
+
+		stream = create(:stream, organization: organization, default: true)
+		stream.make_default
+
+		described_class.perform_now(organization.default_stream)
+		expect(organization.default_stream.current_full_dump.interstream_delta).to be(nil)
+	end
+
+	it 'Creates an interstream delta with proper additions and deletes' do
+		GenerateFullDumpJob.perform_now(organization)
+
+		stream = create(:stream, organization: organization, default: false)
+		organization.default_stream.default = false
+		organization.default_stream.save
+
+		stream.make_default
+		
+		stream.uploads << build(:upload, :marc_xml2)
+		# Organization.find is used because it is loading an older version of the organization with the wrong
+		# default stream. Unsure of the best way to 'refresh' so it's pulling the correct default
+		GenerateFullDumpJob.perform_now(Organization.find(organization.id))
+
+		described_class.perform_now(stream)
+
+		expect(stream.current_full_dump.interstream_delta).not_to be(nil)
+
+		# Deltas should contain one addition (we find two instances of 'record' in the xml for <record> and </record>)
+		xml = stream.current_full_dump.interstream_delta.marcxml.open { |file| File.readlines(file) }.to_s
+		expect(xml.scan(/record/).count).to be(2)
+
+		# Deltas should contain two deletions
+		deletes = stream.current_full_dump.interstream_delta.deletes.open { |file | File.readlines(file) }
+		expect(deletes.count).to be(2)
+	end
 end

--- a/spec/jobs/generate_interstream_delta_job_spec.rb
+++ b/spec/jobs/generate_interstream_delta_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GenerateInterstreamDeltaJob, type: :job do
+	let(:organization) { create(:organization) }
+
+	before do
+    	organization.default_stream.uploads << build(:upload, :binary_marc)
+		organization.default_stream.uploads << build(:upload, :long_file)
+		organization.default_stream.uploads << build(:upload, :binary_marc)
+  	end
+
+	it 'Does not create an interstream delta if there is no previous default stream' do
+		GenerateFullDumpJob.perform_now(organization)
+		described_class.perform_now(organization.default_stream)
+		expect(organization.default_stream.current_full_dump.interstream_delta).to be(nil)
+	end
+
+	# test for no result on no existing dump for previous stream
+	# test for no result on no existing dump for current stream
+end

--- a/spec/jobs/generate_interstream_delta_job_spec.rb
+++ b/spec/jobs/generate_interstream_delta_job_spec.rb
@@ -3,54 +3,54 @@
 require 'rails_helper'
 
 RSpec.describe GenerateInterstreamDeltaJob, type: :job do
-	let(:organization) { create(:organization) }
+  let(:organization) { create(:organization) }
 
-	before do
-    	organization.default_stream.uploads << build(:upload, :binary_marc)
-		organization.default_stream.uploads << build(:upload, :long_file)
-		organization.default_stream.uploads << build(:upload, :binary_marc)
-  	end
+  before do
+      organization.default_stream.uploads << build(:upload, :binary_marc)
+    organization.default_stream.uploads << build(:upload, :long_file)
+    organization.default_stream.uploads << build(:upload, :binary_marc)
+    end
 
-	it 'Does not create an interstream delta if there is no previous default stream' do
-		GenerateFullDumpJob.perform_now(organization)
-		described_class.perform_now(organization.default_stream)
-		expect(organization.default_stream.current_full_dump.interstream_delta).to be(nil)
-	end
+  it 'Does not create an interstream delta if there is no previous default stream' do
+    GenerateFullDumpJob.perform_now(organization)
+    described_class.perform_now(organization.default_stream)
+    expect(organization.default_stream.current_full_dump.interstream_delta).to be(nil)
+  end
 
-	it 'Does not create an interstream delta if the current stream is missing a full dump' do
-		GenerateFullDumpJob.perform_now(organization)
+  it 'Does not create an interstream delta if the current stream is missing a full dump' do
+    GenerateFullDumpJob.perform_now(organization)
 
-		stream = create(:stream, organization: organization, default: true)
-		stream.make_default
+    stream = create(:stream, organization: organization, default: true)
+    stream.make_default
 
-		described_class.perform_now(organization.default_stream)
-		expect(organization.default_stream.current_full_dump.interstream_delta).to be(nil)
-	end
+    described_class.perform_now(organization.default_stream)
+    expect(organization.default_stream.current_full_dump.interstream_delta).to be(nil)
+  end
 
-	it 'Creates an interstream delta with proper additions and deletes' do
-		GenerateFullDumpJob.perform_now(organization)
+  it 'Creates an interstream delta with proper additions and deletes' do
+    GenerateFullDumpJob.perform_now(organization)
 
-		stream = create(:stream, organization: organization, default: false)
-		organization.default_stream.default = false
-		organization.default_stream.save
+    stream = create(:stream, organization: organization, default: false)
+    organization.default_stream.default = false
+    organization.default_stream.save
 
-		stream.make_default
-		
-		stream.uploads << build(:upload, :marc_xml2)
-		# Organization.find is used because it is loading an older version of the organization with the wrong
-		# default stream. Unsure of the best way to 'refresh' so it's pulling the correct default
-		GenerateFullDumpJob.perform_now(Organization.find(organization.id))
+    stream.make_default
+    
+    stream.uploads << build(:upload, :marc_xml2)
+    # Organization.find is used because it is loading an older version of the organization with the wrong
+    # default stream. Unsure of the best way to 'refresh' so it's pulling the correct default
+    GenerateFullDumpJob.perform_now(Organization.find(organization.id))
 
-		described_class.perform_now(stream)
+    described_class.perform_now(stream)
 
-		expect(stream.current_full_dump.interstream_delta).not_to be(nil)
+    expect(stream.current_full_dump.interstream_delta).not_to be(nil)
 
-		# Deltas should contain one addition (we find two instances of 'record' in the xml for <record> and </record>)
-		xml = stream.current_full_dump.interstream_delta.marcxml.open { |file| File.readlines(file) }.to_s
-		expect(xml.scan(/record/).count).to be(2)
+    # Deltas should contain one addition (we find two instances of 'record' in the xml for <record> and </record>)
+    xml = stream.current_full_dump.interstream_delta.marcxml.open { |file| File.readlines(file) }.to_s
+    expect(xml.scan(/record/).count).to be(2)
 
-		# Deltas should contain two deletions
-		deletes = stream.current_full_dump.interstream_delta.deletes.open { |file | File.readlines(file) }
-		expect(deletes.count).to be(2)
-	end
+    # Deltas should contain two deletions
+    deletes = stream.current_full_dump.interstream_delta.deletes.open { |file | File.readlines(file) }
+    expect(deletes.count).to be(2)
+  end
 end

--- a/spec/jobs/generate_interstream_delta_job_spec.rb
+++ b/spec/jobs/generate_interstream_delta_job_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe GenerateInterstreamDeltaJob, type: :job do
   let(:organization) { create(:organization) }
 
   before do
-      organization.default_stream.uploads << build(:upload, :binary_marc)
+    organization.default_stream.uploads << build(:upload, :binary_marc)
     organization.default_stream.uploads << build(:upload, :long_file)
     organization.default_stream.uploads << build(:upload, :binary_marc)
-    end
+  end
 
   it 'Does not create an interstream delta if there is no previous default stream' do
     GenerateFullDumpJob.perform_now(organization)
     described_class.perform_now(organization.default_stream)
-    expect(organization.default_stream.current_full_dump.interstream_delta).to be(nil)
+    expect(organization.default_stream.current_full_dump.interstream_delta).to be_nil
   end
 
   it 'Does not create an interstream delta if the current stream is missing a full dump' do
@@ -24,9 +24,10 @@ RSpec.describe GenerateInterstreamDeltaJob, type: :job do
     stream.make_default
 
     described_class.perform_now(organization.default_stream)
-    expect(organization.default_stream.current_full_dump.interstream_delta).to be(nil)
+    expect(organization.default_stream.current_full_dump.interstream_delta).to be_nil
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it 'Creates an interstream delta with proper additions and deletes' do
     GenerateFullDumpJob.perform_now(organization)
 
@@ -35,7 +36,7 @@ RSpec.describe GenerateInterstreamDeltaJob, type: :job do
     organization.default_stream.save
 
     stream.make_default
-    
+
     stream.uploads << build(:upload, :marc_xml2)
     # Organization.find is used because it is loading an older version of the organization with the wrong
     # default stream. Unsure of the best way to 'refresh' so it's pulling the correct default
@@ -43,14 +44,13 @@ RSpec.describe GenerateInterstreamDeltaJob, type: :job do
 
     described_class.perform_now(stream)
 
-    expect(stream.current_full_dump.interstream_delta).not_to be(nil)
-
     # Deltas should contain one addition (we find two instances of 'record' in the xml for <record> and </record>)
     xml = stream.current_full_dump.interstream_delta.marcxml.open { |file| File.readlines(file) }.to_s
     expect(xml.scan(/record/).count).to be(2)
 
     # Deltas should contain two deletions
-    deletes = stream.current_full_dump.interstream_delta.deletes.open { |file | File.readlines(file) }
+    deletes = stream.current_full_dump.interstream_delta.deletes.open { |file| File.readlines(file) }
     expect(deletes.count).to be(2)
   end
+  # rubocop:enable RSpec/ExampleLength
 end

--- a/spec/models/interstream_delta_spec.rb
+++ b/spec/models/interstream_delta_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe InterstreamDelta, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/interstream_delta_spec.rb
+++ b/spec/models/interstream_delta_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe InterstreamDelta, type: :model do


### PR DESCRIPTION
Creates a new job that, provided a stream (or stream id for use in manually running the job) will generate the deltas between its full dump and the last good state of the previous default stream in the default stream history (Last good state of previous stream = the full dump + deltas)