### PR TITLE
OAI ListSets response

### DIFF
--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 # Produce OAI-PMH responses
+# rubocop:disable Metrics/ClassLength
 class OaiController < ApplicationController
   load_and_authorize_resource :organization
 
   def show
-    if params[:verb] == 'ListRecords'
+    case params[:verb]
+    when 'ListRecords'
       render_list_records
+    when 'ListSets'
+      render_list_sets
     else
       render_error('badVerb')
     end
@@ -14,16 +18,30 @@ class OaiController < ApplicationController
 
   private
 
+  # rubocop:disable Metrics/AbcSize
   def render_list_records
     headers['Cache-Control'] = 'no-cache'
     headers['Last-Modified'] = Time.current.httpdate
     headers['X-Accel-Buffering'] = 'no'
 
-    self.response_body = build_list_records_response(*list_record_normalized_dump_candidates.first(2))
+    @organization = Organization.find_by(slug: params[:set])
+    @stream = @organization.default_stream
+    authorize! :read, @stream
+
+    render xml: build_list_records_response(*list_record_normalized_dump_candidates.first(2))
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def render_list_sets
+    headers['Cache-Control'] = 'no-cache'
+    headers['Last-Modified'] = Time.current.httpdate
+    headers['X-Accel-Buffering'] = 'no'
+
+    render xml: build_list_sets_response(Organization.providers)
   end
 
   def render_error(code)
-    error = <<-XML
+    error = <<~XML
       <?xml version="1.0" encoding="UTF-8"?>
       <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -96,6 +114,29 @@ class OaiController < ApplicationController
   end
   # rubocop:enable Metrics/MethodLength
 
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
+  def build_list_sets_response(organizations)
+    Nokogiri::XML::Builder.new do |xml|
+      xml.send :'OAI-PMH', oai_xmlns do
+        xml.responseDate Time.zone.now.iso8601
+        xml.request(oai_params.to_hash) do
+          xml.text oai_url
+        end
+        xml.ListSets do
+          organizations.each do |organization|
+            xml.set do
+              xml.setSpec organization.slug
+              xml.setName organization.name
+            end
+          end
+        end
+      end
+    end.to_xml
+  end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
+
   def read_oai_xml(dump, chunk_size: 1.megabyte)
     return to_enum(:read_oai_xml, dump, chunk_size: chunk_size) unless block_given?
 
@@ -109,4 +150,15 @@ class OaiController < ApplicationController
       io.close
     end
   end
+
+  # XML namespace values for OAI-PMH, see:
+  # https://www.openarchives.org/OAI/openarchivesprotocol.html#XMLResponse
+  def oai_xmlns
+    {
+      'xmlns' => 'http://www.openarchives.org/OAI/2.0/',
+      'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+      'xsi:schemaLocation' => 'http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd'
+    }
+  end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -17,6 +17,7 @@ class Organization < ApplicationRecord
   has_many :statistics, dependent: :delete_all, as: :resource
   accepts_nested_attributes_for :contact_email, update_only: true
   has_many :users, -> { distinct }, through: :roles, class_name: 'User', source: :users
+  scope :providers, -> { where(provider: true) }
 
   def default_stream
     @default_stream ||= streams.find_or_create_by(default: true)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
   get '/documentation/:id', to: 'pages#show', as: :pages
   get '/api', to: 'pages#api'
-
+  get '/oai', to: 'oai#show'
 
   get 'contact_emails/confirm/:token', to: 'contact_emails#confirm', as: :contact_email_confirmation
 
@@ -34,7 +34,6 @@ Rails.application.routes.draw do
       get 'resourcelist', to: 'organizations#index', defaults: { format: :xml }
       get 'normalized_resourcelist/:flavor', to: 'organizations#index', defaults: { normalized: true, format: :xml }, as: :normalized_resourcelist
     end
-    get 'oai', to: 'oai#show'
 
     member do
       get 'normalized_data'

--- a/spec/features/oai_spec.rb
+++ b/spec/features/oai_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'OAI-PMH', type: :feature do
+  let(:organization) { create(:organization, name: 'My Org', slug: 'my-org') }
+  let(:user) { create(:user) }
+
+  # NOTE: capybara matchers don't always seem to work on returned XML documents;
+  # parsing the response using Nokogiri is required for some assertions
+
+  before do
+    user.add_role :member, organization
+    login_as(user, scope: :user)
+  end
+
+  it 'renders responses with a utf-8 xml content type' do
+    visit oai_url
+    expect(page.response_headers['Content-Type']).to eq('application/xml; charset=utf-8')
+  end
+
+  it 'renders an error if no verb is supplied' do
+    visit oai_url
+    expect(page).to have_selector('error[code="badVerb"]')
+  end
+
+  it 'renders an error if an unknown verb is supplied' do
+    visit oai_url(verb: 'Oops')
+    expect(page).to have_selector('error[code="badVerb"]')
+  end
+
+  it 'renders the time the request was submitted in iso8601 format' do
+    visit oai_url
+    doc = Nokogiri::XML(page.body)
+    expect(doc.at_css('responseDate').content).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)
+  end
+
+  it 'renders the request params and root url as an element' do
+    visit oai_url(verb: 'ListSets')
+    expect(page).to have_selector('request[verb="ListSets"]', text: oai_url)
+  end
+
+  context 'when the verb is ListSets' do
+    it 'renders a set element for each organization' do
+      visit oai_url(verb: 'ListSets')
+      doc = Nokogiri::XML(page.body)
+      expect(doc.at_css('ListSets > set > setName').text).to eq('My Org')
+      expect(doc.at_css('ListSets > set > setSpec').text).to eq('my-org')
+    end
+  end
+end


### PR DESCRIPTION
This PR also moves the OAI-PMH api to `/oai` (instead of being per-organization), since [the spec says](https://www.openarchives.org/OAI/openarchivesprotocol.html#HTTPRequestFormat):
> There is a single base URL for all requests. The base URL specifies the Internet host and port, and optionally a path, of an HTTP server acting as a repository.