### PR TITLE
Add tests for verified permission behavior in app

### DIFF
--- a/spec/features/homepage_summary_spec.rb
+++ b/spec/features/homepage_summary_spec.rb
@@ -55,5 +55,25 @@ RSpec.describe 'homepage summary', type: :feature do
     it 'displays the processing status of any active jobs' do
       expect(page).to have_content '2 jobs active'
     end
+
+    it 'displays the Provider home link' do
+      expect(page).to have_link 'Provider home'
+    end
+  end
+
+  context 'when not logged in' do
+    before do
+      visit '/'
+    end
+
+    it 'displays info for logging in' do
+      expect(page).to have_content 'Already a POD user?'
+      expect(page).to have_link 'Login'
+      expect(page).to have_css('a.btn')
+    end
+
+    it 'displays links to docs' do
+      expect(page).to have_content 'Check out the POD wiki or contact pod-support@lists.stanford.edu'
+    end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -83,25 +83,24 @@ RSpec.describe Ability do
       it { is_expected.not_to be_able_to(:delete, default_stream) }
 
       # Owner organization
-      it { is_expected.to be_able_to(:read, organization) }
+      it { is_expected.to be_able_to(:manage, organization) }
       it { is_expected.to be_able_to(:normalized_data, organization) }
       it { is_expected.to be_able_to(:processing_status, organization) }
       it { is_expected.to be_able_to(:users, organization) }
       it { is_expected.to be_able_to(:organization_details, organization) }
       it { is_expected.to be_able_to(:provider_details, organization) }
 
-      it { is_expected.to be_able_to(:read, Upload.new(organization: organization)) }
-      it { is_expected.to be_able_to(:create, Upload.new(organization: organization)) }
+      it { is_expected.to be_able_to(:crud, Upload.new(organization: organization)) }
 
-      it { is_expected.to be_able_to(:read, Stream.new(organization: organization)) }
+      it { is_expected.to be_able_to(:crud, Stream.new(organization: organization)) }
       it { is_expected.to be_able_to(:profile, Stream.new(organization: organization)) }
-      it { is_expected.to be_able_to(:create, Stream.new(organization: organization)) }
+      it { is_expected.to be_able_to(:info, Stream.new(organization: organization)) }
       it { is_expected.not_to be_able_to(:reanalyze, Stream.new(organization: organization)) }
 
-      it { is_expected.to be_able_to(:read, AllowlistedJwt.new(resource: organization)) }
-      it { is_expected.to be_able_to(:create, AllowlistedJwt.new(resource: organization)) }
+      it { is_expected.to be_able_to(:crud, AllowlistedJwt.new(resource: organization)) }
 
       # Non-member organization
+      it { is_expected.not_to be_able_to(:manage, not_my_org) }
       it { is_expected.to be_able_to(:read, not_my_org) }
       it { is_expected.to be_able_to(:normalized_data, not_my_org) }
       it { is_expected.to be_able_to(:processing_status, not_my_org) }
@@ -114,10 +113,11 @@ RSpec.describe Ability do
 
       it { is_expected.to be_able_to(:read, Stream.new(organization: not_my_org)) }
       it { is_expected.to be_able_to(:profile, Stream.new(organization: not_my_org)) }
+      it { is_expected.to be_able_to(:info, Stream.new(organization: not_my_org)) }
       it { is_expected.not_to be_able_to(:create, Stream.new(organization: not_my_org)) }
+      it { is_expected.not_to be_able_to(:reanalyze, Stream.new(organization: not_my_org)) }
 
-      it { is_expected.not_to be_able_to(:read, AllowlistedJwt.new(resource: not_my_org)) }
-      it { is_expected.not_to be_able_to(:create, AllowlistedJwt.new(resource: not_my_org)) }
+      it { is_expected.not_to be_able_to(:crud, AllowlistedJwt.new(resource: not_my_org)) }
     end
 
     context 'with a member of an org' do
@@ -130,6 +130,7 @@ RSpec.describe Ability do
       it { is_expected.not_to be_able_to(:delete, default_stream) }
 
       # Member organization
+      it { is_expected.not_to be_able_to(:manage, organization) }
       it { is_expected.to be_able_to(:read, organization) }
       it { is_expected.to be_able_to(:normalized_data, organization) }
       it { is_expected.to be_able_to(:processing_status, organization) }
@@ -147,8 +148,11 @@ RSpec.describe Ability do
 
       it { is_expected.to be_able_to(:read, AllowlistedJwt.new(resource: organization)) }
       it { is_expected.not_to be_able_to(:create, AllowlistedJwt.new(resource: organization)) }
+      it { is_expected.not_to be_able_to(:update, AllowlistedJwt.new(resource: organization)) }
+      it { is_expected.not_to be_able_to(:destroy, AllowlistedJwt.new(resource: organization)) }
 
       # Non-member organization
+      it { is_expected.not_to be_able_to(:manage, not_my_org) }
       it { is_expected.to be_able_to(:read, not_my_org) }
       it { is_expected.to be_able_to(:normalized_data, not_my_org) }
       it { is_expected.to be_able_to(:processing_status, not_my_org) }
@@ -163,8 +167,7 @@ RSpec.describe Ability do
       it { is_expected.to be_able_to(:profile, Stream.new(organization: not_my_org)) }
       it { is_expected.not_to be_able_to(:create, Stream.new(organization: not_my_org)) }
 
-      it { is_expected.not_to be_able_to(:read, AllowlistedJwt.new(resource: not_my_org)) }
-      it { is_expected.not_to be_able_to(:create, AllowlistedJwt.new(resource: not_my_org)) }
+      it { is_expected.not_to be_able_to(:crud, AllowlistedJwt.new(resource: not_my_org)) }
     end
   end
 end

--- a/spec/views/organization_users/index.html.erb_spec.rb
+++ b/spec/views/organization_users/index.html.erb_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe 'organization_users/index', type: :view do
       render
       expect(rendered).to have_css("a[href='#{organization_user_path(organization, owner)}'][data-method='delete']")
     end
+
+    it 'renders a link to invite new user' do
+      render
+      expect(rendered).to have_link 'Invite new user to organization'
+    end
   end
 
   context 'when a user has both member and owner roles' do

--- a/spec/views/organizations/index.html.erb_spec.rb
+++ b/spec/views/organizations/index.html.erb_spec.rb
@@ -3,12 +3,47 @@
 require 'rails_helper'
 
 RSpec.describe 'organizations/index', type: :view do
+  let(:org1) { create(:organization, name: 'Organization 1') }
+  let(:org2) { create(:organization, name: 'Organization 2') }
+  let(:org3) { create(:organization, name: 'Organization 3', provider: false) }
+
   before do
-    assign(:organizations, [create(:organization, name: 'Name1'), create(:organization)])
+    assign(:organizations, [org1, org2, org3])
   end
 
   it 'renders a list of organizations' do
     render
-    assert_select 'tr>td', text: 'Name1'.to_s
+
+    assert_select 'tr>td', text: 'Organization 1'
+    assert_select 'tr>td', text: 'Organization 2'
+    assert_select 'tr>td', text: 'Organization 3'
+  end
+
+  it 'renders 2 charts' do
+    render
+
+    assert_select '#chart-1'
+    assert_select '#chart-2'
+  end
+
+  it 'renders Destroy button if privileged' do
+    allow(view).to receive(:can?).and_return(true)
+    render
+
+    assert_select 'a.btn', text: 'Destroy'
+  end
+
+  it 'renders Edit button if privileged' do
+    allow(view).to receive(:can?).and_return(true)
+    render
+
+    assert_select 'a.btn', text: 'Edit'
+  end
+
+  it 'renders New organization button if privileged' do
+    allow(view).to receive(:can?).and_return(true)
+    render
+
+    assert_select 'a.btn', text: 'New organization'
   end
 end

--- a/spec/views/organizations/organization_details.html.erb_spec.rb
+++ b/spec/views/organizations/organization_details.html.erb_spec.rb
@@ -4,10 +4,11 @@ require 'rails_helper'
 
 RSpec.describe 'organizations/organization_details', type: :view do
   let(:organization) { create(:organization, name: 'Best University') }
-  let(:admin) { create(:admin) }
+  let(:contact_email) { create(:contact_email, organization: organization) }
 
   before do
     assign(:organization, organization)
+    assign(:contact_email, contact_email)
   end
 
   # rubocop:disable RSpec/ExampleLength
@@ -20,6 +21,7 @@ RSpec.describe 'organizations/organization_details', type: :view do
       assert_select 'input[name=?]', 'organization[slug]'
       assert_select 'input[name=?]', 'organization[code]'
       assert_select 'input[name=?]', 'organization[provider]'
+      assert_select 'input[name=?]', 'organization[contact_email_attributes][email]'
     end
   end
   # rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
This work is related to #634

I added tests for non-controversial permissions items in the spreadsheet that were missing tests. Everything tested here was in sync between the app and the spreadsheet. Getting these tests in before making further changes would be good.

