### PR TITLE
Send confirm email only when email field is updated; fix flash message.

### DIFF
--- a/app/controllers/contact_emails_controller.rb
+++ b/app/controllers/contact_emails_controller.rb
@@ -10,10 +10,10 @@ class ContactEmailsController < ApplicationController
 
     respond_to do |format|
       if @contact_email.confirm!
-        format.html { render_or_redirect_with_flash notice: 'Contact email confirmed' }
+        format.html { render_or_redirect_with_flash notice: 'The POD contact for this organization has been confirmed.' }
         format.json { head :no_content }
       else
-        format.html { render_or_redirect_with_flash error: 'Unable to confirm contact email' }
+        format.html { render_or_redirect_with_flash error: 'Unable to confirm contact email.' }
         format.json { render json: @contact_email.errors, status: :unprocessable_entity }
       end
     end
@@ -21,7 +21,7 @@ class ContactEmailsController < ApplicationController
 
   def render_or_redirect_with_flash(**messages)
     messages.each do |key, value|
-      flash.now[key] = value
+      flash.keep[key] = value
     end
 
     if can? :read, @contact_email.organization

--- a/app/models/contact_email.rb
+++ b/app/models/contact_email.rb
@@ -13,7 +13,9 @@ class ContactEmail < ApplicationRecord
   end
 
   after_commit do
-    ContactEmailsMailer.with(contact_email: self).confirm_email.deliver_later if confirmation_sent_at.blank?
+    if confirmation_sent_at.blank? && saved_change_to_attribute?(:email)
+      ContactEmailsMailer.with(contact_email: self).confirm_email.deliver_later
+    end
   end
 
   def confirm!

--- a/spec/models/contact_email_spec.rb
+++ b/spec/models/contact_email_spec.rb
@@ -21,11 +21,14 @@ RSpec.describe ContactEmail, type: :model do
     end
   end
 
+  # rubocop:disable RSpec/SubjectStub
   it 'sends a confirmation email' do
+    allow(contact_email).to receive(:saved_change_to_attribute?).with(:email).and_return(true)
     expect do
-      contact_email.save
+      contact_email.update(email: 'someone@example.com')
     end.to have_enqueued_mail(ContactEmailsMailer, :confirm_email)
   end
+  # rubocop:enable RSpec/SubjectStub
 
   describe '#confirm!' do
     before { contact_email.save }


### PR DESCRIPTION
I'm ignoring the issue of whether we care if the contact email gets confirmed or not before displaying it. Right now it displays right away. Fixes #722 and Fixes #723 