### PR TITLE
Update styling and labels on new upload page

### DIFF
--- a/app/views/uploads/_form.html.erb
+++ b/app/views/uploads/_form.html.erb
@@ -1,11 +1,11 @@
 <%= bootstrap_form_with(model: [@organization, upload], local: true, multipart: true) do |form| %>
-  <%= form.text_field :name %>
+  <%= form.text_field :name, label: 'Upload name' %>
 
   <%= hidden_field_tag(:stream, (upload.stream || current_stream).friendly_id) unless (upload.stream || current_stream).default? %>
 
-  <div class="custom-file">
-    <%= form.file_field_without_bootstrap :files, type: :file, multiple: true, direct_upload: true, id: 'customFile', class: 'custom-file-input' %>
+  <div class="custom-file mt-4">
     <label class="custom-file-label" for="customFile">Upload file</label>
+    <%= form.file_field_without_bootstrap :files, type: :file, multiple: true, direct_upload: true, id: 'customFile', class: 'custom-file-input mt-2' %>
   </div>
 
   <div class="direct-upload-area row mt-1"></div>
@@ -17,6 +17,6 @@
   <%= form.text_field :url, placeholder: 'https://example.com/12345.marc', label: 'Upload via URL' %>
 
   <div class="actions mt-3">
-    <%= form.primary %>
+    <%= form.primary 'Create upload' %>
   </div>
 <% end %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -1,9 +1,9 @@
 <%= render 'shared/organization_header' %>
 
 <div class="container">
-  <h1>New upload</h1>
+  <h2>Create new upload</h2>
 
-  <div class="alert alert-info" role="alert">
+  <div class="alert alert-info mt-3" role="alert">
     <p>
       You can also upload by submitting a POST with an http client (e.g. curl command).  Note that you should only provide either <code>upload[files][]</code> <strong>OR</strong> <code>upload[url]</code>.
     </p>

--- a/spec/features/upload_spec.rb
+++ b/spec/features/upload_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'uploading files to POD', type: :feature do
       click_on 'Best University'
       click_on 'Upload file'
       attach_file('Upload file', Rails.root.join('spec/fixtures/stanford-50.mrc.gz'))
-      click_on 'Create Upload'
+      click_on 'Create upload'
 
       expect(page).to have_content 'stanford-50.mrc.gz'
       expect(page).to have_content '17.8 KB application/gzip'


### PR DESCRIPTION
Some minor updates for better spacing and heading level and case consistency:

- Page header to `<h2>` and label updated
- Moved "Upload file" label before the upload button, rather than after it (hopefully this doesn't affect form functioning -- I wouldn't think it would -- but I didn't actually test the form after my changes because I don't know what to upload)
- Added some minor vertical spacing to separate elements better
- Changed the submit button label to sentence case to match our application style

### Before
<img width="1029" alt="Screen Shot 2022-04-29 at 4 11 19 PM" src="https://user-images.githubusercontent.com/101482/166079685-ea401d86-9b35-4cea-8f86-16a2a18925e2.png">

### After
<img width="1029" alt="Screen Shot 2022-04-29 at 4 02 58 PM" src="https://user-images.githubusercontent.com/101482/166079698-ebc21db0-2233-406e-895e-ecd833a38a84.png">

