### PR TITLE
Update formatting of new stream page

### DIFF
--- a/app/views/streams/_form.html.erb
+++ b/app/views/streams/_form.html.erb
@@ -3,6 +3,6 @@
   <%= form.text_field :slug %>
 
   <div class="actions">
-    <%= form.primary %>
+    <%= form.primary 'Create stream' %>
   </div>
 <% end %>

--- a/app/views/streams/new.html.erb
+++ b/app/views/streams/new.html.erb
@@ -1,7 +1,7 @@
 <%= render 'shared/organization_header' %>
 
 <div class="container">
-  <h1>New stream</h1>
+  <h2>Create new stream</h2>
 
   <%= render 'form', stream: @stream %>
 </div>


### PR DESCRIPTION
A few minor updates to the new stream page for better consistency:

- Make the page header an `<h2>` and update label
- Make the button label sentence-case

### Before

<img width="1038" alt="Screen Shot 2022-05-02 at 2 16 34 PM" src="https://user-images.githubusercontent.com/101482/166329949-db9de663-7a24-4a0c-b3ed-41ddb2200589.png">


### After
<img width="1038" alt="Screen Shot 2022-05-02 at 2 19 54 PM" src="https://user-images.githubusercontent.com/101482/166329938-48642a80-abd2-4d93-a643-31dfd1cf0e1f.png">

