### PR TITLE
Add stats clarification to provider list section

### DIFF
--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -15,8 +15,11 @@
     </div>
   <% end %>
 
-  <h2>Upload statistics by provider</h2>
+  <h2>Default stream statistics by provider</h2>
 
+  <p>
+    Statistics are calculated daily and might not reflect the most recent uploads.
+  </p>
   <table class="table table-striped organizations mt-4">
     <thead>
       <tr>


### PR DESCRIPTION
On the Providers page:

- Updated the section heading to more accurately reflect what the table shows
- Added a line to clarify that the stats are generated daily, not after each upload

<img width="747" alt="Screen Shot 2022-05-05 at 3 48 53 PM" src="https://user-images.githubusercontent.com/101482/167038704-74e05843-f6c9-43f9-9b4f-4034cd1ae934.png">

