### PR TITLE
Update styling of files table legend

### DIFF
--- a/app/assets/stylesheets/pod-icons.scss
+++ b/app/assets/stylesheets/pod-icons.scss
@@ -26,6 +26,8 @@
 }
 
 .pod-metadata-status {
+  vertical-align: text-bottom;
+
   &.deletes {
     color: $success;
   }
@@ -45,4 +47,8 @@
   &.unknown {
     color: $info;
   }
+}
+
+.table-key li {
+  margin-bottom: 0.33rem;
 }

--- a/app/views/dashboard/uploads.html.erb
+++ b/app/views/dashboard/uploads.html.erb
@@ -4,7 +4,7 @@
     <% Settings.metadata_status.each do |status, values| %>
     <li class="list-inline-item">
       <%= bootstrap_icon(values.icon_class, class: "pod-metadata-status #{status}") %>
-      <span class="fw-bold"><%= values.label %></span>
+      <span><%= values.label %></span>
     </li>
     <% end %>
   </ul>

--- a/app/views/uploads/_file_table.html.erb
+++ b/app/views/uploads/_file_table.html.erb
@@ -2,7 +2,7 @@
   <% Settings.metadata_status.each do |status, values| %>
   <li class="list-inline-item">
     <%= bootstrap_icon(values.icon_class, class: "pod-metadata-status #{status}") %>
-    <span class="fw-bold"><%= values.label %></span>
+    <span><%= values.label %></span>
   </li>
   <% end %>
 </ul>


### PR DESCRIPTION
Closes #763.

Minor styling update:

- Remove bolding from text
- Vertically align text and icons at bottom
- Ensure that when the legend info wraps on narrower viewports, there is decent vertical space between the wrapped lines

### Before
<img width="1039" alt="Screen Shot 2022-05-06 at 3 35 26 PM" src="https://user-images.githubusercontent.com/101482/167224518-ac63db5b-8af2-4f4a-b8d8-6cb3afabb4bc.png">


### After
<img width="1039" alt="Screen Shot 2022-05-06 at 3 34 22 PM" src="https://user-images.githubusercontent.com/101482/167224527-a7618300-411f-4d2e-ae9c-7392e789d938.png">

