### PR TITLE
Update styling of Normalized data section

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -170,3 +170,18 @@ input[type=file][data-direct-upload-url][disabled] {
   background-color: $warning;
   max-width: 100vw;
 }
+
+.info-box {
+  margin-bottom: 1.5rem;
+  margin-top: 1rem;
+
+  .card-header {
+    padding-bottom: 0.25rem;
+    padding-top: 0.25rem;
+
+    .text-info {
+      margin-right: 0.25rem;
+      vertical-align: text-bottom;
+    }
+  }
+}

--- a/app/views/streams/_normalized_dump.html.erb
+++ b/app/views/streams/_normalized_dump.html.erb
@@ -1,21 +1,15 @@
 <% if normalized_dump %>
-  <div class="card mt-5">
-    <div class="card-header d-flex justify-content-between">
-      <h3 class="h5 align-self-center mb-0">Normalized data</h3>
-    </div>
+  <table class="table table-striped mb-0">
+    <thead><th>Type</th><th class="pl-4">File</th><th>Date created</th><th>Size</th><th class="text-end pr-4">Records</th></thead>
+    <tbody>
+      <%= render partial: 'streams/dump_attachment', locals: { type: 'Full', attachment: normalized_dump.marc21.attachment, stream: normalized_dump.stream } %>
+      <%= render partial: 'streams/dump_attachment', locals: { type: 'Full', attachment: normalized_dump.marcxml.attachment, stream: normalized_dump.stream } %>
 
-    <table class="table table-striped mb-0">
-      <thead><th></th><th class="pl-4">File</th><th>Date created</th><th>Size</th><th class="text-end pr-4">Records</th></thead>
-      <tbody>
-        <%= render partial: 'streams/dump_attachment', locals: { type: 'Full', attachment: normalized_dump.marc21.attachment, stream: normalized_dump.stream } %>
-        <%= render partial: 'streams/dump_attachment', locals: { type: 'Full', attachment: normalized_dump.marcxml.attachment, stream: normalized_dump.stream } %>
-
-        <% normalized_dump.deltas.sort_by(&:created_at).each do |delta| %>
-          <%= render partial: 'streams/dump_attachment', locals: { type: 'Delta', attachment: delta.marc21.attachment, stream: normalized_dump.stream } %>
-          <%= render partial: 'streams/dump_attachment', locals: { type: 'Delta', attachment: delta.marcxml.attachment, stream: normalized_dump.stream } %>
-          <%= render partial: 'streams/dump_attachment', locals: { type: 'Deletes', attachment: delta.deletes.attachment, stream: normalized_dump.stream } %>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
+      <% normalized_dump.deltas.sort_by(&:created_at).each do |delta| %>
+        <%= render partial: 'streams/dump_attachment', locals: { type: 'Delta', attachment: delta.marc21.attachment, stream: normalized_dump.stream } %>
+        <%= render partial: 'streams/dump_attachment', locals: { type: 'Delta', attachment: delta.marcxml.attachment, stream: normalized_dump.stream } %>
+        <%= render partial: 'streams/dump_attachment', locals: { type: 'Deletes', attachment: delta.deletes.attachment, stream: normalized_dump.stream } %>
+      <% end %>
+    </tbody>
+  </table>
 <% end %>

--- a/app/views/streams/normalized_data.html.erb
+++ b/app/views/streams/normalized_data.html.erb
@@ -1,10 +1,10 @@
 <%= render 'shared/layout_stream_page' do %>
   <h3>Normalized data</h3>
 
-  <div class="card">
+  <div class="card info-box">
     <div class="card-header">
       <h5 class="card-title-info mt-2">
-        <%= bootstrap_icon("info-circle-fill", class: "text-primary") %>
+        <%= bootstrap_icon("info-circle-fill", class: "text-info") %>
         <span class="ml-2"><%= t('pages.home.providers.normalized_data.about_title_html') %></span>
       </h5>
     </div>


### PR DESCRIPTION
The current Normalized data section is a bit outdated in that we're still embedding the table inside a card, including a card header with the same "Normalized data" heading we've already shown in the section header. The card approach was useful when the provider page had a bunch of different sections and the card header helped visually separate them. But since we've moved the sections to their own pages, the card header is just redundant with the section header above it.

<img width="1029" alt="current" src="https://user-images.githubusercontent.com/101482/167227959-835887e3-d444-4579-bbc3-cd0a44c0301c.png">

---

This PR fixes that, plus some other minor styling things:

- Added "Type" as a column header for the first column
- Fine-tuned styling of the info box to be slightly more compact, use the more semantically appropriate `info` class for the icon, and given the icon a bit more separation from the box heading
- Added a bit more vertical space between the section heading and the start of the info box
- Added the info box styling to SCSS so if and when we want to add another info box somewhere, the styling will be consistent (if you add an `info-box` class to the outer `card` div used for the info box)

### After
(Note that I don't have any normalized data locally, so didn't actually have a normalized data table to verify everything is as I expect -- the screenshot below is from the equivalent web inspector updates on the -prod site -- but I can double-check when this is merged to verify everything is as intended.)

<img width="1041" alt="Screen Shot 2022-05-06 at 4 22 19 PM" src="https://user-images.githubusercontent.com/101482/167227909-e642b00b-08df-45a6-b8fc-e23715db2158.png">

