### PR TITLE
Refactor DefaultStreamHistories

### DIFF
--- a/app/jobs/generate_interstream_delta_job.rb
+++ b/app/jobs/generate_interstream_delta_job.rb
@@ -14,10 +14,9 @@ class GenerateInterstreamDeltaJob < ApplicationJob
 
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def perform(stream)
-    previous_stream_history = stream.default_stream_history.previous_stream_history
-    return if previous_stream_history.nil?
+    return if stream.previous_default_stream_history.blank?
 
-    previous_stream = previous_stream_history.stream
+    previous_stream = stream.previous_default_stream_history.stream
 
     current_stream_dump = stream.current_full_dump
     previous_stream_dump = previous_stream.current_full_dump

--- a/app/models/default_stream_history.rb
+++ b/app/models/default_stream_history.rb
@@ -2,13 +2,6 @@
 
 # History of an organizations' default streams
 class DefaultStreamHistory < ApplicationRecord
-  belongs_to :organization
   belongs_to :stream
-
-  def previous_stream_history
-    # Get previous stream history
-    histories = organization.default_stream_histories.all.order(start_time: :desc)
-    index = histories.find_index { |stream_history| stream_history.stream == stream }
-    histories[index + 1]
-  end
+  has_one :organization, through: :stream, inverse_of: :default_stream_histories
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -8,7 +8,7 @@ class Organization < ApplicationRecord
   friendly_id :name, use: %i[finders slugged]
   has_paper_trail
   has_many :streams, dependent: :destroy
-  has_many :default_stream_histories, dependent: :destroy
+  has_many :default_stream_histories, through: :streams, inverse_of: :organization
   has_many :uploads, through: :streams
   has_many :marc_records, through: :streams, inverse_of: :organization
   has_many :allowlisted_jwts, as: :resource, dependent: :delete_all

--- a/db/migrate/20220509152922_remove_organizations_fk_from_default_stream_histories.rb
+++ b/db/migrate/20220509152922_remove_organizations_fk_from_default_stream_histories.rb
@@ -1,0 +1,5 @@
+class RemoveOrganizationsFkFromDefaultStreamHistories < ActiveRecord::Migration[7.0]
+  def change
+    remove_foreign_key :default_stream_histories, :organizations
+  end
+end

--- a/db/migrate/20220509160015_remove_organization_id_from_default_stream_histories.rb
+++ b/db/migrate/20220509160015_remove_organization_id_from_default_stream_histories.rb
@@ -1,0 +1,5 @@
+class RemoveOrganizationIdFromDefaultStreamHistories < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :default_stream_histories, :organization_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2022_04_13_204319) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_09_160015) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -108,6 +109,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_13_204319) do
     t.datetime "updated_at", null: false
     t.index ["confirmation_token"], name: "index_contact_emails_on_confirmation_token", unique: true
     t.index ["organization_id"], name: "index_contact_emails_on_organization_id"
+  end
+
+  create_table "default_stream_histories", force: :cascade do |t|
+    t.bigint "stream_id", null: false
+    t.datetime "start_time", precision: nil, null: false
+    t.datetime "end_time", precision: nil
+    t.index ["stream_id"], name: "index_default_stream_histories_on_stream_id"
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|
@@ -290,6 +298,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_13_204319) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "contact_emails", "organizations"
+  add_foreign_key "default_stream_histories", "streams"
   add_foreign_key "marc_profiles", "uploads"
   add_foreign_key "normalized_dumps", "streams"
 end

--- a/spec/models/stream_spec.rb
+++ b/spec/models/stream_spec.rb
@@ -92,4 +92,43 @@ RSpec.describe Stream, type: :model do
       expect { current_default.make_default }.not_to(change { current_default.reload.default })
     end
   end
+
+  describe '#previous_default_stream_history' do
+    let(:org) { create(:organization) }
+    let(:stream00) { create(:stream, organization: org, default: true) }
+    let(:stream01) { create(:stream, organization: org) }
+    let(:stream02) { create(:stream, organization: org) }
+
+    before do
+      stream01.reload.make_default
+      stream02.reload.make_default
+    end
+
+    it 'returns the previous default stream history' do
+      expect(stream02.previous_default_stream_history).to eq(stream01.default_stream_histories.first)
+    end
+
+    it 'returns nil if there is not a previous default stream history' do
+      expect(stream00.previous_default_stream_history).to be_nil
+    end
+
+    context 'when the stream has been default more than once' do
+      before do
+        stream01.reload.make_default
+      end
+
+      it 'returns the previous default stream history for the most recent period when a datetime is not supplied' do
+        expect(stream01.previous_default_stream_history).to eq(stream02.default_stream_histories.first)
+      end
+
+      it 'returns the previous default stream history for the datetime supplied' do
+        datetime = stream01.default_stream_histories.first.start_time.strftime('%Y-%m-%d %H:%M:%S.%N')
+        expect(stream01.previous_default_stream_history(datetime)).to eq(stream00.default_stream_histories.first)
+      end
+
+      it 'returns nil if the datetime supplied is not within a range when the stream has been the default' do
+        expect(stream01.previous_default_stream_history('2008-05-10 12:50:35')).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
The relationships between DefaultStreamHistory, Stream, and Organization were not quite right. This adjusts the model relationships to prevent foreign key violations (when deleting an organization, etc.). It also moves to the Stream model the method for getting the previous default stream history object for a stream. Adds test coverage.
Fixes #789