### PR TITLE
Fix rack-attack throttle logging

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -6,6 +6,6 @@ Rack::Attack.throttle("logins/ip", limit: 10, period: 12.hours) do |req|
   req.ip if req.post? && req.path.start_with?("/users/sign_in")
 end
 
-ActiveSupport::Notifications.subscribe("rack.attack") do |name, start, finish, request_id, req|
-  puts "Throttled #{req.env["rack.attack.match_discriminator"]}"
+ActiveSupport::Notifications.subscribe("rack.attack") do |name, start, finish, request_id, payload|
+  puts "Throttled #{payload[:request].env["rack.attack.match_discriminator"]}"
 end


### PR DESCRIPTION
> NoMethodError: undefined method `env' for {:request=>#<Rack::Attack::Request:0x00007fb3868e5fa8 @params=nil, @env={"REQUEST_URI"=>"/users/sign_in", "PATH_INFO"=>"/500", "SCRIPT_NAME"=>"", "QUERY_STRING"=>"", "REQUEST_METHOD"=>"GET", "SERVER_NAME"=>"pod.stanford.edu", "SERVER_PORT"=>"443", "SERVER_SOFTWARE"=>"Apache/2.4.6 () OpenSSL/1.0.2k-fips Phusion_Passenger/6.0.12", "SERVER_PROTOCOL"=>"HTTP/1.1", "REMOT...