### PR TITLE
Update headings for better accessibility

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -171,17 +171,7 @@ input[type=file][data-direct-upload-url][disabled] {
   max-width: 100vw;
 }
 
-.info-box {
-  margin-bottom: 1.5rem;
-  margin-top: 1rem;
-
-  .card-header {
-    padding-bottom: 0.25rem;
-    padding-top: 0.25rem;
-
-    .text-info {
-      margin-right: 0.25rem;
-      vertical-align: text-bottom;
-    }
-  }
+.text-info {
+  margin-right: 0.25rem;
+  vertical-align: text-bottom;
 }

--- a/app/assets/stylesheets/organizations.scss
+++ b/app/assets/stylesheets/organizations.scss
@@ -41,9 +41,15 @@
 
 dl.organization-details {
   dt {
-    font-weight: normal;
+    font-weight: 500;
   }
-  dt > *:last-child {
-    padding-left: 15px;
+
+  dd {
+    margin-bottom: 1rem;
+    margin-left: 1rem;
+
+    img {
+      max-width: 35px;
+    }
   }
 }

--- a/app/views/marc_profiles/_fields.html.erb
+++ b/app/views/marc_profiles/_fields.html.erb
@@ -1,4 +1,4 @@
-<h3 class="mt-5">Non-standard fields</h3>
+<h4 class="mt-5">Non-standard fields</h4>
 <table class="table table-striped mt-4">
   <thead>
     <tr>
@@ -35,7 +35,7 @@
   </tbody>
 </table>
 
-<h3 class="mt-5">Non-standard subfields</h3>
+<h4 class="mt-5">Non-standard subfields</h4>
 <table class="table table-striped mt-4">
   <thead>
     <tr>

--- a/app/views/marc_profiles/_histogram.html.erb
+++ b/app/views/marc_profiles/_histogram.html.erb
@@ -1,4 +1,4 @@
-<h3 class="mt-5">Distribution of occurrences by MARC data field</h3>
+<h4 class="mt-5">Distribution of occurrences by MARC data field</h4>
 <table class="table mt-4">
   <thead>
     <tr>

--- a/app/views/marc_profiles/_summary.html.erb
+++ b/app/views/marc_profiles/_summary.html.erb
@@ -1,4 +1,4 @@
-<h3 class="mt-5">Summary</h3>
+<h4 class="mt-4">Summary</h4>
 <table class="table table-striped mt-4">
   <thead>
     <tr>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -5,11 +5,11 @@
   <% unless params[:page] %>
     <div class="row mb-5 mt-4">
       <div class="col">
-        <h2 class="text-center h6">Files</h2>
+        <h3 class="text-center h6">Files</h3>
         <%= line_chart uploads_chart_path %>
       </div>
       <div class="col">
-        <h2 class="text-center h6">Records</h2>
+        <h3 class="text-center h6">Records</h3>
         <%= line_chart records_chart_path %>
       </div>
     </div>

--- a/app/views/organizations/organization_details.html.erb
+++ b/app/views/organizations/organization_details.html.erb
@@ -16,30 +16,28 @@
   <!-- Member view: -->
   <% else %>
   <dl class="organization-details">
-    <dt>
-      <h4>Name</h4>
-      <p class="<%= @organization.name.blank? ? 'fst-italic' : '' %>">
-        <%= @organization.name.blank? ? 'no value provided' : @organization.name %>
-      </p>
-    </dt>
-    <dt>
-      <h4>Code</h4>
-      <p class="<%= @organization.code.blank? ? 'fst-italic' : '' %>">
+    <dt>Name</dt>
+    <dd class="<%= @organization.name.blank? ? 'fst-italic' : '' %>">
+      <%= @organization.name.blank? ? 'no value provided' : @organization.name %>
+    </dd>
+
+    <dt>Code</dt>
+    <dd class="<%= @organization.code.blank? ? 'fst-italic' : '' %>">
         <%= @organization.code.blank? ? 'no value provided' : @organization.code %>
-      </p>
-    </dt>
-    <dt>
-      <h4>POD contact for this organization</h4>
-      <p class="<%= @organization.contact_email.blank? ? 'fst-italic' : '' %>">
+    </dd>
+
+    <dt>POD contact for this organization</dt>
+    <dd>
+      <direct_upload class="<%= @organization.contact_email.blank? ? 'fst-italic' : '' %>">
         <%= @organization.contact_email.blank? ? 'no value provided' : @organization.contact_email.email %>
-      </p>
-    </dt>
-    <dt>
-      <h4>Icon</h4>
+    </dd>
+
+    <dt>Icon</dt>
+    <dd>
       <% if @organization.icon.attached? %>
-      <%= image_tag(@organization.icon, class: 'organization-icon') %>
+      <%= image_tag(@organization.icon, class: 'organization-icon mt-2') %>
       <% end %>
-    </dt>
+    </dd>
   </dl>
   <% end %>
 <% end %>

--- a/app/views/organizations/provider_details.html.erb
+++ b/app/views/organizations/provider_details.html.erb
@@ -13,26 +13,29 @@
 
     <!-- Member view: -->
     <% else %>
-    <dl class="organization-details mt-4">
-        <dt>
-            <h4>What MARC field contains item-level information?</h4>
-            <p class="<%= @organization.normalization_steps.values.dig(0, 'source_tag').blank? ? 'fst-italic' : '' %>">
+        <dl class="organization-details mt-4">
+            <dt>What MARC field contains item-level information?</dt>
+            <dd>
+                <p class="<%= @organization.normalization_steps.values.dig(0, 'source_tag').blank? ? 'fst-italic' : '' %>">
                 <%= @organization.normalization_steps.values.dig(0, 'source_tag').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'source_tag') %>
-            </p>
-        </dt>
-        <dt>
-            <h4>Local identifier subfield</h4>
-            <p class="<%= @organization.normalization_steps.values.dig(0, 'subfields', 'i').blank? ? 'fst-italic' : '' %>"><%= @organization.normalization_steps.values.dig(0, 'subfields', 'i').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'subfields', 'i') %></p>
-        </dt>
-        <dt>
-            <h4>Call number subfield</h4>
-            <p class="<%= @organization.normalization_steps.values.dig(0, 'subfields', 'a').blank? ? 'fst-italic' : '' %>"><%= @organization.normalization_steps.values.dig(0, 'subfields', 'a').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'subfields', 'a')%></p>
-        </dt>
-        <dt>
-            <h4>Local library</h4>
+                </p>
+            </dd>
+
+            <dt>Local identifier subfield</dt>
+            <dd>
+                <p class="<%= @organization.normalization_steps.values.dig(0, 'subfields', 'i').blank? ? 'fst-italic' : '' %>"><%= @organization.normalization_steps.values.dig(0, 'subfields', 'i').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'subfields', 'i') %></p>
+            </dd>
+
+            <dt>Call number subfield</dt>
+            <dd>
+                <p class="<%= @organization.normalization_steps.values.dig(0, 'subfields', 'a').blank? ? 'fst-italic' : '' %>"><%= @organization.normalization_steps.values.dig(0, 'subfields', 'a').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'subfields', 'a')%></p>
+            </dd>
+
+            <dt>Local library</dt>
+            <dd>
             <p class="<%= @organization.normalization_steps.values.dig(0, 'subfields', 'm').blank? ? 'fst-italic' : '' %>"><%= @organization.normalization_steps.values.dig(0, 'subfields', 'm').blank? ? 'no value provided' : @organization.normalization_steps.values.dig(0, 'subfields', 'm') %></p>
-        </dt>
-    </dl>
+            </dd>
+        </dl>
     <% end %>
 </div>
 <% end %>

--- a/app/views/pages/data.html.erb
+++ b/app/views/pages/data.html.erb
@@ -1,4 +1,5 @@
 <div class="container index-page">
+  <h1 class="visually-hidden">Data</h1>
   <h2><%= t('.guidelines.header') %></h2>
   <p><%= t('.guidelines.body_html') %></p>
 
@@ -14,9 +15,9 @@
   <h3><%= t('.resource_sync.header') %></h3>
   <p><%= t('.resource_sync.body_html') %></p>
 
-  <div class="card w-50 my-4">
-      <div class="card-header d-flex justify-content-between">
-        <h2 class="h6"><%= t('.resource_sync.sitemaps') %></h2>
+  <div class="card my-4">
+      <div class="card-header">
+        <h4 class="h6 mb-0"><%= t('.resource_sync.sitemaps') %></h4>
       </div>
       <ul class="list-group list-group-flush">
         <li class="list-group-item"><%= link_to t('.resource_sync.original_uploads'), resourcelist_organizations_url %> (real-time)</li>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -58,7 +58,7 @@
     <div class="mt-3 mt-md-5 d-md-flex justify-content-md-around">
       <% unless @overview.last_org_files.empty? %>
       <div class="my-2 my-md-0">
-        <h3>
+        <h3 class="h4">
           <%= t('.organization.uploads.heading') %>
         </h3>
         <ul class="list-unstyled">
@@ -74,7 +74,7 @@
       <% end %>
       <% if @overview.organization.provider? %>
       <div class="my-2 my-md-0">
-        <h3>
+        <h3 class="h4">
           <%= t('.organization.jobs.heading') %>
         </h3>
         <ul class="list-unstyled">
@@ -96,7 +96,7 @@
       </div>
       <% end %>
       <div class="my-2 my-md-0">
-        <h3>
+        <h3 class="h4">
           <%= t('.organization.actions.heading') %>
         </h3>
         <ul class="list-unstyled">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,5 @@
 <footer class="bg-light border-top mt-3 py-3 py-md-4">
+  <h2 class="visually-hidden">Resources</h2>
   <div class="container">
     <div class="row">
       <div class="col-md my-3 my-md-0">
@@ -9,7 +10,7 @@
         </div>
       </div>
       <div class="col-md my-3 my-md-0">
-        <h5><%= t('.docs.heading') %></h5>
+        <h3 class="h5"><%= t('.docs.heading') %></h3>
         <ul class="list-unstyled mb-1">
           <li>
             <%= link_to t('.docs.api'), 'https://github.com/pod4lib/aggregator/wiki/Uploading-data-using-the-API', class: 'text-muted text-decoration-none' %>
@@ -23,7 +24,7 @@
         </ul>
       </div>
       <div class="col-md my-3 my-md-0">
-        <h5><%= t('.resources.heading') %></h5>
+        <h3 class="h5"><%= t('.resources.heading') %></h3>
         <ul class="list-unstyled mb-1">
           <li>
             <%= link_to t('.resources.contributing'), 'https://github.com/pod4lib/aggregator/wiki#getting-help', class: 'text-muted text-decoration-none' %>

--- a/app/views/streams/normalized_data.html.erb
+++ b/app/views/streams/normalized_data.html.erb
@@ -1,12 +1,12 @@
 <%= render 'shared/layout_stream_page' do %>
   <h3>Normalized data</h3>
 
-  <div class="card info-box">
+  <div class="card my-3">
     <div class="card-header">
-      <h5 class="card-title-info mt-2">
+      <h4 class="h6 mb-0 ">
         <%= bootstrap_icon("info-circle-fill", class: "text-info") %>
         <span class="ml-2"><%= t('pages.home.providers.normalized_data.about_title_html') %></span>
-      </h5>
+      </h4>
     </div>
     <div class="card-body">
       <p class="card-text"><%= t('pages.home.providers.normalized_data.about_description_html') %></p>


### PR DESCRIPTION
Updates to heading levels throughout the application to ensure we're using a proper hierarchy on each page. There will be other accessibility-related updates we need to make; I just focused on headings in this PR.

I also made minor styling and HTML updates when they were directly related to heading changes. For example, I rewrote the `dl`s for the read-only view of Organization details and Provider details because I don't think we need the `dt`s to be headings and the `dl`s were unnecessarily complex. Example:

### Before

<img width="818" alt="Screen Shot 2022-05-20 at 9 27 45 AM" src="https://user-images.githubusercontent.com/101482/169572463-84966a32-e4ca-416e-b195-538da2df35cd.png">


### After

<img width="818" alt="Screen Shot 2022-05-20 at 9 27 01 AM" src="https://user-images.githubusercontent.com/101482/169572448-00878385-dd09-4346-bcdb-0ce216d3931f.png">

