### PR TITLE
Re-label 'Destroy' buttons with more user-friendly term

### DIFF
--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -56,7 +56,7 @@
 
           <% if can? :manage, Organization %>
             <td class="align-middle"><%= link_to 'Edit', organization_details_organization_path(organization), class: 'btn btn-secondary btn-sm' if can? :edit, organization %></td>
-            <td class="align-middle"><%= link_to 'Destroy', organization, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' if can? :destroy, organization %></td>
+            <td class="align-middle"><%= link_to 'Delete', organization, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' if can? :destroy, organization %></td>
           <% end %>
 
         </tr>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -27,7 +27,7 @@
           <td><%= link_to upload.name, [@organization, upload] %></td>
           <td><%= local_time(upload.created_at, format: datetime_display_format()) %></td>
           <td><%= link_to upload.stream.display_name, organization_stream_path(upload.stream.organization, upload.stream) %></td>
-          <td><%= link_to 'Destroy', [@organization, upload], method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' if can? :destroy, upload %></td>
+          <td><%= link_to 'Delete', [@organization, upload], method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' if can? :destroy, upload %></td>
         </tr>
       <% end %>
     </tbody>

--- a/spec/features/providers_spec.rb
+++ b/spec/features/providers_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Viewing provider information', type: :feature do
 
       # don't confuse "Edit" with "Edit Profile" in header nav
       expect(page).not_to have_link('Edit', exact: true)
-      expect(page).not_to have_link 'Destroy'
+      expect(page).not_to have_link 'Delete'
       expect(page).not_to have_link 'New Organization'
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe 'Viewing provider information', type: :feature do
 
       # don't confuse "Edit" with "Edit Profile" in header nav
       expect(page).to have_link('Edit', exact: true)
-      expect(page).to have_link 'Destroy'
+      expect(page).to have_link 'Delete'
       expect(page).to have_link 'New organization'
     end
   end

--- a/spec/views/organizations/index.html.erb_spec.rb
+++ b/spec/views/organizations/index.html.erb_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe 'organizations/index', type: :view do
     assert_select '#chart-2'
   end
 
-  it 'renders Destroy button if privileged' do
+  it 'renders Delete button if privileged' do
     allow(view).to receive(:can?).and_return(true)
     render
 
-    assert_select 'a.btn', text: 'Destroy'
+    assert_select 'a.btn', text: 'Delete'
   end
 
   it 'renders Edit button if privileged' do

--- a/spec/views/uploads/index.html.erb_spec.rb
+++ b/spec/views/uploads/index.html.erb_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe 'uploads/index', type: :view do
     expect(rendered).to have_css('tr>td>a', text: stream.name, count: 2)
   end
 
-  it 'shows Destroy button to privileged users' do
+  it 'shows Delete button to privileged users' do
     allow(view).to receive(:can?).and_return(true)
     render
 
-    assert_select 'a.btn', text: 'Destroy'
+    assert_select 'a.btn', text: 'Delete'
   end
 end


### PR DESCRIPTION
There were two pages where we were still using "Destroy" as the label for the destroy buttons. I re-labelled these "Delete" to be more friendly to non-programmer end-users and updated the associated test files.