### PR TITLE
OAI-PMH ListRecords and friends

### DIFF
--- a/app/controllers/concerns/oai_concern.rb
+++ b/app/controllers/concerns/oai_concern.rb
@@ -57,19 +57,12 @@ module OaiConcern
   class ResumptionToken
     def self.encode(set: nil, page: nil, from_date: nil, until_date: nil)
       validate(set, page, from_date, until_date)
-
       Base64.urlsafe_encode64([set, page, from_date, until_date].join(';'))
     end
 
     def self.decode(token)
       set, page, from_date, until_date = Base64.urlsafe_decode64(token).split(';')
-
-      begin
-        validate(set, page, from_date, until_date)
-      rescue ArgumentError
-        raise OaiConcern::BadResumptionToken
-      end
-
+      validate(set, page, from_date, until_date)
       [set, page, from_date, until_date]
     end
 
@@ -78,6 +71,8 @@ module OaiConcern
       Integer(page) if page.present?
       Date.parse(from_date) if from_date.present?
       Date.parse(until_date) if until_date.present?
+    rescue ArgumentError
+      raise OaiConcern::BadResumptionToken
     end
   end
 

--- a/app/controllers/concerns/oai_concern.rb
+++ b/app/controllers/concerns/oai_concern.rb
@@ -60,7 +60,22 @@ module OaiConcern
     end
 
     def self.decode(token)
-      Base64.urlsafe_decode64(token).split(';')
+      set, page, from_date, until_date = Base64.urlsafe_decode64(token).split(';')
+
+      begin
+        validate(set, page, from_date, until_date)
+      rescue ArgumentError
+        raise OaiConcern::BadResumptionToken
+      end
+
+      [set, page, from_date, until_date]
+    end
+
+    def self.validate(set, page, from_date, until_date)
+      Integer(set) if set.present?
+      Integer(page) if page.present?
+      Date.parse(from_date) if from_date.present?
+      Date.parse(until_date) if until_date.present?
     end
   end
 

--- a/app/controllers/concerns/oai_concern.rb
+++ b/app/controllers/concerns/oai_concern.rb
@@ -56,11 +56,13 @@ module OaiConcern
   # list.
   class ResumptionToken
     def self.encode(set, page, from_date, until_date)
-      Base64.urlsafe_encode64([set, page, from_date, until_date].join(';'))
+      # Base64.urlsafe_encode64([set, page, from_date, until_date].join(';'))
+      [set, page, from_date, until_date].join('|')
     end
 
     def self.decode(token)
-      Base64.urlsafe_decode64(token).split(';')
+      # Base64.urlsafe_decode64(token).split(';')
+      token.split('|')
     end
   end
 

--- a/app/controllers/concerns/oai_concern.rb
+++ b/app/controllers/concerns/oai_concern.rb
@@ -55,7 +55,9 @@ module OaiConcern
   # A token lets you construct a list of records and point to somewhere in that
   # list.
   class ResumptionToken
-    def self.encode(set, page, from_date, until_date)
+    def self.encode(set: nil, page: nil, from_date: nil, until_date: nil)
+      validate(set, page, from_date, until_date)
+
       Base64.urlsafe_encode64([set, page, from_date, until_date].join(';'))
     end
 

--- a/app/controllers/concerns/oai_concern.rb
+++ b/app/controllers/concerns/oai_concern.rb
@@ -99,7 +99,6 @@ module OaiConcern
     # rubocop:enable Metrics/AbcSize
   end
 
-  # rubocop:disable Metrics/BlockLength
   included do
     private
 
@@ -124,26 +123,5 @@ module OaiConcern
         'xsi:schemaLocation' => 'http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd'
       }
     end
-
-    def list_sets_description(stream)
-      [[list_sets_default_status(stream),
-        list_sets_stream_info(stream)].join(' '),
-       list_sets_date_ranges(stream)].join(', ')
-    end
-
-    def list_sets_default_status(stream)
-      stream.default? ? 'Current default stream' : 'Former default stream'
-    end
-
-    def list_sets_stream_info(stream)
-      "for #{stream.organization.slug}"
-    end
-
-    def list_sets_date_ranges(stream)
-      stream.default_stream_histories.recent.map do |history|
-        "#{history.start_time} to #{history.end_time.presence || 'present'}"
-      end
-    end
   end
-  # rubocop:enable Metrics/BlockLength
 end

--- a/app/controllers/concerns/oai_concern.rb
+++ b/app/controllers/concerns/oai_concern.rb
@@ -51,6 +51,19 @@ module OaiConcern
     end
   end
 
+  # Token for requesting records: base64-encoded combo of filters & page cursor
+  # A token lets you construct a list of records and point to somewhere in that
+  # list.
+  class ResumptionToken
+    def self.encode(set, page, from_date, until_date)
+      Base64.urlsafe_encode64([set, page, from_date, until_date].join(';'))
+    end
+
+    def self.decode(token)
+      Base64.urlsafe_decode64(token).split(';')
+    end
+  end
+
   included do
     # XML namespace values for OAI-PMH, see:
     # https://www.openarchives.org/OAI/openarchivesprotocol.html#XMLResponse

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -72,7 +72,7 @@ class OaiController < ApplicationController
   # rubocop:enable Metrics/PerceivedComplexity
 
   def render_list_sets
-    render xml: build_list_sets_response(Organization.providers)
+    render xml: build_list_sets_response(Organization.providers.where(public: true))
   end
 
   def render_identify

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -61,7 +61,7 @@ class OaiController < ApplicationController
     # NOTE: this way, we can always call next_record_page the same way.
     # ultimately, a token is just a pointer to somewhere in a list of records,
     # and the filters needed to construct that list of records
-    token ||= OaiConcern::ResumptionToken.encode(set, nil, from_date, until_date)
+    token ||= OaiConcern::ResumptionToken.encode(set: set, from_date: from_date, until_date: until_date)
 
     # render the first page of records along with token for the next one
     render xml: build_list_records_response(*next_record_page(token))
@@ -129,7 +129,7 @@ class OaiController < ApplicationController
   # Get a page of OAI-XML records and a token pointing to the next page
   def next_record_page(token = nil)
     # parse the token if we were provided one
-    set, page, from_date, until_date = *OaiConcern::ResumptionToken.decode(token) if token
+    set, page, from_date, until_date = OaiConcern::ResumptionToken.decode(token) if token
     page = page.to_i
 
     # filter normalized dumps and get the corresponding OAI-XML pages
@@ -143,7 +143,7 @@ class OaiController < ApplicationController
     # generate a token for the next page, if there is one
     token = case page
             when (0...pages.count - 1)
-              OaiConcern::ResumptionToken.encode(set, page + 1, from_date, until_date)
+              OaiConcern::ResumptionToken.encode(set: set, page: page + 1, from_date: from_date, until_date: until_date)
             when (pages.count - 1)
               nil
             else

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -127,6 +127,7 @@ class OaiController < ApplicationController
   def next_record_page(token = nil)
     # parse the token if we were provided one
     set, page, from_date, until_date = *OaiConcern::ResumptionToken.decode(token) if token
+    page = page.to_i
 
     # filter normalized dumps and get the corresponding OAI-XML pages
     # NOTE: each page is guaranteed to have < OAIPMHWriter::max_records_per_file,
@@ -137,9 +138,12 @@ class OaiController < ApplicationController
 
     # generate a token for the next page, if there is one
     token = case page
-            when 0...pages.count then OaiConcern::ResumptionToken.encode(set, page + 1, from_date, until_date)
-            when pages.count then nil
-            else raise OaiConcern::BadResumptionToken
+            when (0...pages.count - 1)
+              OaiConcern::ResumptionToken.encode(set, page + 1, from_date, until_date)
+            when (pages.count - 1)
+              nil
+            else
+              raise OaiConcern::BadResumptionToken
             end
 
     # return the relevant page and the token for the next page, if any

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -28,9 +28,6 @@ class OaiController < ApplicationController
   private
 
   # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def render_list_records
     headers['Cache-Control'] = 'no-cache'
     headers['Last-Modified'] = Time.current.httpdate
@@ -67,9 +64,6 @@ class OaiController < ApplicationController
     render xml: build_list_records_response(*next_record_page(token))
   end
   # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
   def render_list_sets
     render xml: build_list_sets_response(Organization.providers)
@@ -151,7 +145,7 @@ class OaiController < ApplicationController
   end
 
   # Get all NormalizedDumps from a particular org or created between two dates
-  # NOTE: this likely needs work to memoize/tune, but it should be called 
+  # NOTE: this likely needs work to memoize/tune, but it should be called
   # repeatedly by next_record_page with the same arguments
   def normalized_dumps(set, from_date, until_date)
     # get candidate streams (all defaults or single org default)

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -212,10 +212,15 @@ class OaiController < ApplicationController
           streams.each do |stream|
             xml.set do
               xml.setSpec stream.id
-              xml.setName "#{stream.organization.slug}, stream #{stream.display_name}"
+              xml.setName stream.display_name
               xml.setDescription do
                 xml[:oai_dc].dc(oai_dc_xmlns) do
-                  xml[:dc].description list_sets_description(stream)
+                  xml[:dc].description stream.oai_dc_description
+                  xml[:dc].contributor stream.organization.slug
+                  xml[:dc].type stream.oai_dc_type
+                  stream.oai_dc_dates.each do |date|
+                    xml[:dc].date date
+                  end
                 end
               end
             end

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -201,10 +201,12 @@ class OaiController < ApplicationController
       build_oai_response xml, list_records_params do
         xml.ListRecords do
           read_oai_xml(page) { |data| xml << data }
-          xml.resumptionToken do
-            xml.text token if token
-            # NOTE: consider adding completeListSize and cursor (page) here
-            # see https://www.openarchives.org/OAI/openarchivesprotocol.html#FlowControl
+          if token
+            xml.resumptionToken do
+              xml.text token
+              # NOTE: consider adding completeListSize and cursor (page) here
+              # see https://www.openarchives.org/OAI/openarchivesprotocol.html#FlowControl
+            end
           end
         end
       end

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -155,7 +155,7 @@ class OaiController < ApplicationController
   # repeatedly by next_record_page with the same arguments
   def normalized_dumps(set, from_date, until_date)
     # get candidate streams (all defaults or single org default)
-    streams = set ? Stream.default.joins(:organization).where(organization: { slug: set }) : Stream.default
+    streams = set.present? ? Stream.default.joins(:organization).where(organization: { slug: set }) : Stream.default
 
     dumps = filter_dumps(streams, from_date, until_date)
 
@@ -170,8 +170,8 @@ class OaiController < ApplicationController
     dumps = streams.flat_map(&:current_dumps).sort_by(&:created_at)
 
     # filter candidate dumps (by from date and until date)
-    dumps = dumps.select { |dump| dump.created_at >= Time.zone.parse(from_date).beginning_of_day } if from_date
-    dumps = dumps.select { |dump| dump.created_at <= Time.zone.parse(until_date).end_of_day } if until_date
+    dumps = dumps.select { |dump| dump.created_at >= Time.zone.parse(from_date).beginning_of_day } if from_date.present?
+    dumps = dumps.select { |dump| dump.created_at <= Time.zone.parse(until_date).end_of_day } if until_date.present?
 
     dumps
   end

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -140,7 +140,7 @@ class OaiController < ApplicationController
             end
 
     # return the relevant page and the token for the next page, if any
-    [pages.offset(page).limit(1), token]
+    [pages[page], token]
   end
 
   # Get all NormalizedDumps from a particular org or created between two dates

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -200,9 +200,14 @@ class OaiController < ApplicationController
     Nokogiri::XML::Builder.new do |xml|
       build_oai_response xml, list_records_params do
         xml.ListRecords do
-          read_oai_xml(page).each do |chunk|
-            xml << chunk
+          # TODO: Cory: Since these appear to be just plain text files just
+          #             read the content until we create actual gzip files
+          page.blob.open do |tmpfile|
+            xml << tmpfile.read
           end
+          # read_oai_xml(page).each do |chunk|
+          #   xml << chunk
+          # end
           xml.resumptionToken do
             xml.text token if token
             # NOTE: consider adding completeListSize and cursor (page) here
@@ -282,6 +287,7 @@ class OaiController < ApplicationController
   end
 
   # Stream an OAI-XML file 1M at a time
+  # TODO: Cory: the OAI-XML file doesn't appear to be a Gzip file?
   def read_oai_xml(file, chunk_size: 1.megabyte)
     return to_enum(:read_oai_xml, file, chunk_size: chunk_size) unless block_given?
 

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -28,6 +28,9 @@ class OaiController < ApplicationController
   private
 
   # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/PerceivedComplexity
   def render_list_records
     headers['Cache-Control'] = 'no-cache'
     headers['Last-Modified'] = Time.current.httpdate
@@ -64,6 +67,9 @@ class OaiController < ApplicationController
     render xml: build_list_records_response(*next_record_page(token))
   end
   # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def render_list_sets
     render xml: build_list_sets_response(Organization.providers)

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -61,7 +61,7 @@ class OaiController < ApplicationController
     token ||= OaiConcern::ResumptionToken.encode(set, nil, from_date, until_date)
 
     # render the first page of records along with token for the next one
-    render xml: build_list_records_response(next_record_page(token))
+    render xml: build_list_records_response(*next_record_page(token))
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -192,12 +192,10 @@ class OaiController < ApplicationController
           read_oai_xml(page).each do |chunk|
             xml << chunk
           end
-          if token
-            xml.resumptionToken do
-              xml.text token
-              # NOTE: consider adding completeListSize and cursor (page) here
-              # see https://www.openarchives.org/OAI/openarchivesprotocol.html#FlowControl
-            end
+          xml.resumptionToken do
+            xml.text token if token
+            # NOTE: consider adding completeListSize and cursor (page) here
+            # see https://www.openarchives.org/OAI/openarchivesprotocol.html#FlowControl
           end
         end
       end

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -36,10 +36,13 @@ class OaiController < ApplicationController
     headers['Last-Modified'] = Time.current.httpdate
     headers['X-Accel-Buffering'] = 'no'
 
-    # error if metadataPrefix is anything other than marc21 or empty; per spec
+    # unless a resumptionToken is supplied, error if metadataPrefix
+    # is anything other than marc21 or empty; per spec
     begin
-      md_prefix = list_records_params.require(:metadataPrefix)
-      raise OaiConcern::CannotDisseminateFormat unless md_prefix == 'marc21'
+      unless list_records_params.include?(:resumptionToken)
+        md_prefix = list_records_params.require(:metadataPrefix)
+        raise OaiConcern::CannotDisseminateFormat unless md_prefix == 'marc21'
+      end
     rescue ActionController::ParameterMissing
       raise OaiConcern::BadArgument
     end

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -187,7 +187,7 @@ class OaiController < ApplicationController
           end
           if token
             xml.resumptionToken do
-              xml.text next_dump.id
+              xml.text token
               # NOTE: consider adding completeListSize and cursor (page) here
               # see https://www.openarchives.org/OAI/openarchivesprotocol.html#FlowControl
             end

--- a/app/jobs/generate_delta_dump_job.rb
+++ b/app/jobs/generate_delta_dump_job.rb
@@ -84,7 +84,7 @@ class GenerateDeltaDumpJob < ApplicationJob
     when :errata
       'errata.gz'
     when :oai_xml
-      "oai-#{"-#{format('%010d', counter)}"}.xml"
+      "oai-#{"-#{format('%010d', counter)}"}.xml.gz"
     else
       file_type
     end

--- a/app/jobs/generate_delta_dump_job.rb
+++ b/app/jobs/generate_delta_dump_job.rb
@@ -34,7 +34,7 @@ class GenerateDeltaDumpJob < ApplicationJob
 
     begin
       NormalizedMarcRecordReader.new(uploads).each_slice(100) do |records|
-        records.each_slice(10) do |record_chunk|
+        records.each_slice(Settings.oai_records_per_file) do |record_chunk|
           oai_writer = OaiMarcRecordWriterService.new(base_name)
           record_chunk.each do |record|
             if record.status == 'delete'

--- a/app/jobs/generate_delta_dump_job.rb
+++ b/app/jobs/generate_delta_dump_job.rb
@@ -46,7 +46,7 @@ class GenerateDeltaDumpJob < ApplicationJob
         end
         oai_writer.finalize
         delta_dump.public_send(:oai_xml).attach(io: File.open(oai_writer.oai_file),
-                                                filename: human_readable_filename(:oai_xml, oai_file_counter))
+                                                filename: human_readable_filename(base_name, :oai_xml, oai_file_counter))
 
         oai_file_counter += 1
         progress.increment(records.length)
@@ -59,7 +59,7 @@ class GenerateDeltaDumpJob < ApplicationJob
 
       writer.files.each do |as, file|
         delta_dump.public_send(as).attach(io: File.open(file),
-                                          filename: human_readable_filename(as))
+                                          filename: human_readable_filename(base_name, as))
       end
 
       delta_dump.save!
@@ -73,20 +73,20 @@ class GenerateDeltaDumpJob < ApplicationJob
 
   private
 
-  def human_readable_filename(file_type, counter = nil)
-    case file_type
-    when :deletes
-      'deletes.del.txt'
-    when :marc21
-      'marc21.mrc.gz'
-    when :marcxml
-      'marcxml.xml.gz'
-    when :errata
-      'errata.gz'
-    when :oai_xml
-      "oai-#{"-#{format('%010d', counter)}"}.xml.gz"
-    else
-      file_type
-    end
+  def human_readable_filename(base_name, file_type, counter = nil)
+    as = case file_type
+         when :deletes
+           'deletes.del.txt'
+         when :marc21
+           'marc21.mrc.gz'
+         when :marcxml
+           'marcxml.xml.gz'
+         when :oai_xml
+           "oai-#{format('%010d', counter)}.xml.gz"
+         else
+           "#{file_type}.gz"
+         end
+
+    "#{base_name}-#{as}"
   end
 end

--- a/app/jobs/generate_delta_dump_job.rb
+++ b/app/jobs/generate_delta_dump_job.rb
@@ -33,7 +33,7 @@ class GenerateDeltaDumpJob < ApplicationJob
     oai_file_counter = 0
 
     begin
-      NormalizedMarcRecordReader.new(uploads).each_slice(100) do |records|
+      NormalizedMarcRecordReader.new(uploads).each_slice(Settings.oai_max_page_size) do |records|
         oai_writer = OaiMarcRecordWriterService.new(base_name)
         records.each do |record|
           if record.status == 'delete'

--- a/app/jobs/generate_delta_dump_job.rb
+++ b/app/jobs/generate_delta_dump_job.rb
@@ -50,6 +50,9 @@ class GenerateDeltaDumpJob < ApplicationJob
                                                   filename: human_readable_filename(:oai_xml, oai_file_counter))
 
           oai_file_counter += 1
+        ensure
+          oai_writer.close
+          oai_writer.unlink
         end
 
         progress.increment(records.length)

--- a/app/jobs/generate_full_dump_job.rb
+++ b/app/jobs/generate_full_dump_job.rb
@@ -41,11 +41,15 @@ class GenerateFullDumpJob < ApplicationJob
           writer.write_marc_record(record)
           oai_writer.write_marc_record(record)
         end
-        oai_writer.finalize
-        full_dump.public_send(:oai_xml).attach(io: File.open(oai_writer.oai_file),
-                                               filename: human_readable_filename(
-                                                 base_name, "oai_xml-#{format('%010d', oai_file_counter)}"
-                                               ))
+
+
+        if File.size?(oai_writer.oai_file)
+          oai_writer.finalize
+          full_dump.public_send(:oai_xml).attach(io: File.open(oai_writer.oai_file),
+                                                 filename: human_readable_filename(
+                                                   base_name, "oai_xml-#{format('%010d', oai_file_counter)}"
+                                                 ))
+        end
 
         oai_file_counter += 1
         progress.increment(records.length)

--- a/app/jobs/generate_full_dump_job.rb
+++ b/app/jobs/generate_full_dump_job.rb
@@ -33,7 +33,7 @@ class GenerateFullDumpJob < ApplicationJob
 
     begin
       NormalizedMarcRecordReader.new(uploads).each_slice(100) do |records|
-        records.each_slice(10) do |record_chunk|
+        records.each_slice(Settings.oai_records_per_file) do |record_chunk|
           oai_writer = OaiMarcRecordWriterService.new(base_name)
           record_chunk.each do |record|
             # In a full dump, we can omit the deletes

--- a/app/jobs/generate_full_dump_job.rb
+++ b/app/jobs/generate_full_dump_job.rb
@@ -32,7 +32,7 @@ class GenerateFullDumpJob < ApplicationJob
     oai_file_counter = 0
 
     begin
-      NormalizedMarcRecordReader.new(uploads).each_slice(100) do |records|
+      NormalizedMarcRecordReader.new(uploads).each_slice(Settings.oai_max_page_size) do |records|
         oai_writer = OaiMarcRecordWriterService.new(base_name)
         records.each do |record|
           # In a full dump, we can omit the deletes

--- a/app/jobs/generate_full_dump_job.rb
+++ b/app/jobs/generate_full_dump_job.rb
@@ -14,7 +14,7 @@ class GenerateFullDumpJob < ApplicationJob
     end
   end
 
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
   def perform(organization)
     now = Time.zone.now
     uploads = Upload.active.where(stream: organization.default_stream)
@@ -42,7 +42,6 @@ class GenerateFullDumpJob < ApplicationJob
           oai_writer.write_marc_record(record)
         end
 
-
         if File.size?(oai_writer.oai_file)
           oai_writer.finalize
           full_dump.public_send(:oai_xml).attach(io: File.open(oai_writer.oai_file),
@@ -54,6 +53,7 @@ class GenerateFullDumpJob < ApplicationJob
         oai_file_counter += 1
         progress.increment(records.length)
       ensure
+        oai_writer.finalize
         oai_writer.close
         oai_writer.unlink
       end
@@ -72,7 +72,7 @@ class GenerateFullDumpJob < ApplicationJob
       writer.unlink
     end
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
 
   def human_readable_filename(base_name, file_type)
     as = case file_type

--- a/app/jobs/generate_full_dump_job.rb
+++ b/app/jobs/generate_full_dump_job.rb
@@ -50,6 +50,9 @@ class GenerateFullDumpJob < ApplicationJob
 
           oai_file_counter += 1
           progress.increment(records.length)
+        ensure
+          oai_writer.close
+          oai_writer.unlink
         end
       end
 

--- a/app/jobs/generate_full_dump_job.rb
+++ b/app/jobs/generate_full_dump_job.rb
@@ -42,11 +42,11 @@ class GenerateFullDumpJob < ApplicationJob
           oai_writer.write_marc_record(record)
         end
 
-        if File.size?(oai_writer.oai_file)
+        if oai_writer.bytes_written?
           oai_writer.finalize
           full_dump.public_send(:oai_xml).attach(io: File.open(oai_writer.oai_file),
                                                  filename: human_readable_filename(
-                                                   base_name, "oai_xml-#{format('%010d', oai_file_counter)}"
+                                                   base_name, :oai_xml, oai_file_counter
                                                  ))
         end
 
@@ -74,7 +74,7 @@ class GenerateFullDumpJob < ApplicationJob
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
 
-  def human_readable_filename(base_name, file_type)
+  def human_readable_filename(base_name, file_type, counter = nil)
     as = case file_type
          when :deletes
            'deletes.del.txt'
@@ -83,7 +83,7 @@ class GenerateFullDumpJob < ApplicationJob
          when :marcxml
            'marcxml.xml.gz'
          when :oai_xml
-           "#{file_type}.xml"
+           "oai-#{format('%010d', counter)}.xml.gz"
          else
            "#{file_type}.gz"
          end

--- a/app/models/marc_record.rb
+++ b/app/models/marc_record.rb
@@ -23,7 +23,7 @@ class MarcRecord < ApplicationRecord
 
   # See http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm
   def oai_id
-    "oai:pod.stanford.edu:#{organization.slug}:#{marc001}"
+    "oai:pod.stanford.edu:#{organization.slug}:#{stream.id}:#{marc001}"
   end
 
   def augmented_marc

--- a/app/models/marc_record.rb
+++ b/app/models/marc_record.rb
@@ -21,6 +21,11 @@ class MarcRecord < ApplicationRecord
     self.json = Zlib::Deflate.new.deflate(record.to_marchash.to_json, Zlib::FINISH)
   end
 
+  # See http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm
+  def oai_id
+    "oai:pod.stanford.edu:#{organization.slug}:#{marc001}"
+  end
+
   def augmented_marc
     return marc unless upload.organization
 

--- a/app/models/normalized_dump.rb
+++ b/app/models/normalized_dump.rb
@@ -12,7 +12,7 @@ class NormalizedDump < ApplicationRecord
 
   has_one_attached :marc21
   has_one_attached :marcxml
-  has_one_attached :oai_xml
+  has_many_attached :oai_xml
   has_one_attached :deletes
   has_many_attached :errata
 end

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -76,6 +76,11 @@ class Stream < ApplicationRecord
                            normalized_dumps.full_dumps.create(last_delta_dump_at: Time.zone.at(0))
   end
 
+  # the current full dump and its associated deltas
+  def current_dumps
+    [current_full_dump, *current_full_dump.deltas]
+  end
+  
   # If no datetime is provided then assume we want the previous DefaultStreamHistory
   # object for the most recent period when self.stream was the default.
   #

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -80,7 +80,7 @@ class Stream < ApplicationRecord
   def current_dumps
     [current_full_dump, *current_full_dump.deltas]
   end
-  
+
   # If no datetime is provided then assume we want the previous DefaultStreamHistory
   # object for the most recent period when self.stream was the default.
   #

--- a/app/services/marc_record_writer_service.rb
+++ b/app/services/marc_record_writer_service.rb
@@ -52,6 +52,8 @@ class MarcRecordWriterService
     write_errata("#{record['001']}: #{e}")
   end
 
+  # TODO: make this write multiple files per record if necessary, broken up by
+  # OAIPMHWriter::max_records_per_file
   def write_oai_record(record)
     oai_writer.write(record.augmented_marc, record.oai_id, record.organization.slug, record.upload.created_at)
   rescue StandardError => e
@@ -100,6 +102,10 @@ class MarcRecordWriterService
   class OAIPMHWriter
     def initialize(io)
       @io = io
+    end
+
+    def max_records_per_file
+      1000
     end
 
     def write(record, identifier, set, datestamp = Time.zone.now)

--- a/app/services/marc_record_writer_service.rb
+++ b/app/services/marc_record_writer_service.rb
@@ -66,10 +66,6 @@ class MarcRecordWriterService
     @writers[:deletes] ||= file(:deletes)
   end
 
-  def oai_writer
-    @writers[:oai_xml] ||= OAIPMHWriter.new(Zlib::GzipWriter.new(file(:oai_xml)))
-  end
-
   def gzipped_temp_file(name)
     Zlib::GzipWriter.new(temp_file(name))
   end

--- a/app/services/oai_marc_record_writer_service.rb
+++ b/app/services/oai_marc_record_writer_service.rb
@@ -39,7 +39,7 @@ class OaiMarcRecordWriterService
   private
 
   def oai_writer
-    @oai_writer ||= OAIPMHWriter.new(Zlib::GzipWriter.new(oai_file))
+    @oai_writer ||= OAIPMHWriter.new(oai_file)
   end
 
   # Special logic for writing OAI-PMH-style record responses

--- a/app/services/oai_marc_record_writer_service.rb
+++ b/app/services/oai_marc_record_writer_service.rb
@@ -9,7 +9,7 @@ class OaiMarcRecordWriterService
   end
 
   def write_marc_record(record)
-    oai_writer.write(record.augmented_marc, record.oai_id, record.organization.slug, record.upload.created_at)
+    oai_writer.write(record.augmented_marc, record.oai_id, record.stream.id, record.upload.created_at)
   rescue StandardError => e
     error = "Error writing MARC OAI file #{record.oai_id}: #{e}"
     Rails.logger.info(error)
@@ -17,7 +17,7 @@ class OaiMarcRecordWriterService
   end
 
   def write_delete(record)
-    oai_writer.write_delete(record.oai_id, record.organization.slug, record.upload.created_at)
+    oai_writer.write_delete(record.oai_id, record.stream.id, record.upload.created_at)
   end
 
   def finalize
@@ -39,7 +39,7 @@ class OaiMarcRecordWriterService
   private
 
   def oai_writer
-    @oai_writer ||= OAIPMHWriter.new(oai_file)
+    @oai_writer ||= OAIPMHWriter.new(Zlib::GzipWriter.new(oai_file))
   end
 
   # Special logic for writing OAI-PMH-style record responses

--- a/app/services/oai_marc_record_writer_service.rb
+++ b/app/services/oai_marc_record_writer_service.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Utility class for serializing MARC records to files
+class OaiMarcRecordWriterService
+  attr_reader :base_name
+
+  def initialize(base_name = nil)
+    @base_name = base_name
+  end
+
+  def write_marc_record(record)
+    oai_writer.write(record.augmented_marc, record.oai_id, record.organization.slug, record.upload.created_at)
+  rescue StandardError => e
+    error = "Error writing MARC OAI file #{record.oai_id}: #{e}"
+    Rails.logger.info(error)
+    Honeybadger.notify(error)
+  end
+
+  def write_delete(record)
+    oai_writer.write_delete(record.oai_id, record.organization.slug, record.upload.created_at)
+  end
+
+  def finalize
+    @oai_writer.close
+  end
+
+  def close
+    @oai_file.close
+  end
+
+  def unlink
+    @oai_file.unlink
+  end
+
+  def oai_file
+    @oai_file ||= Tempfile.new("#{base_name}-oai_xml", binmode: true)
+  end
+
+  private
+
+  def oai_writer
+    @oai_writer ||= OAIPMHWriter.new(Zlib::GzipWriter.new(oai_file))
+  end
+
+  # Special logic for writing OAI-PMH-style record responses
+  class OAIPMHWriter
+    def initialize(io)
+      @io = io
+    end
+
+    def write(record, identifier, set, datestamp = Time.zone.now)
+      @io.write <<-EOXML
+        <record>
+          <header>
+            <identifier>#{identifier}</identifier>
+            <datestamp>#{datestamp.strftime('%F')}</datestamp>
+            <setSpec>#{set}</setSpec>
+          </header>
+          <metadata>
+            #{MARC::XMLWriter.encode(record, include_namespace: true)}
+          </metadata>
+        </record>
+      EOXML
+    end
+
+    def write_delete(identifier, set, datestamp = Time.zone.now)
+      @io.write <<-EOXML
+        <record>
+          <header status="deleted">
+            <identifier>#{identifier}</identifier>
+            <datestamp>#{datestamp.strftime('%F')}</datestamp>
+            <setSpec>#{set}</setSpec>
+          </header>
+        </record>
+      EOXML
+    end
+
+    def close
+      @io.close
+    end
+  end
+end

--- a/app/services/oai_marc_record_writer_service.rb
+++ b/app/services/oai_marc_record_writer_service.rb
@@ -21,15 +21,15 @@ class OaiMarcRecordWriterService
   end
 
   def finalize
-    @oai_writer.close
+    @oai_writer&.close
   end
 
   def close
-    @oai_file.close
+    @oai_file&.close
   end
 
   def unlink
-    @oai_file.unlink
+    @oai_file&.unlink
   end
 
   def oai_file

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,6 +8,8 @@ action_mailer:
   default_options:
     from: 'test@example.com'
 
+oai_records_per_file: 1000
+
 contact_email: 'pod-support@lists.stanford.edu'
 
 marc_fixture_seeds:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,8 +8,6 @@ action_mailer:
   default_options:
     from: 'test@example.com'
 
-oai_records_per_file: 1000
-
 contact_email: 'pod-support@lists.stanford.edu'
 
 marc_fixture_seeds:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,4 +53,4 @@ metadata_status:
     label: 'Unknown'
 
 # max. MARC records per OAI-XML file; also max. size of one page in ListRecords
-oai_max_page_size: 100
+oai_max_page_size: 500

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -51,3 +51,6 @@ metadata_status:
   unknown:
     icon_class: 'question-circle-fill'
     label: 'Unknown'
+
+# max. MARC records per OAI-XML file; also max. size of one page in ListRecords
+oai_max_page_size: 100

--- a/spec/factories/upload.rb
+++ b/spec/factories/upload.rb
@@ -48,6 +48,17 @@ FactoryBot.define do
       end
     end
 
+    trait :marc_xml3 do
+      after(:build) do |upload|
+        upload.files.attach(
+          io: File.open(
+            Rails.root.join('spec/fixtures/75163.marcxml')
+          ),
+          filename: '75163.marcxml', content_type: 'application/marcxml+xml'
+        )
+      end
+    end
+
     trait :deleted_binary_marc do
       after(:build) do |upload|
         upload.files.attach(

--- a/spec/factories/upload.rb
+++ b/spec/factories/upload.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
           io: File.open(
             Rails.root.join('spec/fixtures/12345.marcxml')
           ),
-          filename: '1297245.marcxml', content_type: 'application/marcxml+xml'
+          filename: '12345.marcxml', content_type: 'application/marcxml+xml'
         )
       end
     end

--- a/spec/features/homepage_summary_spec.rb
+++ b/spec/features/homepage_summary_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'homepage summary', type: :feature do
     end
 
     it 'displays the most recent files that the org uploaded' do
-      expect(page).to have_content '1297245.marcxml'
+      expect(page).to have_content '12345.marcxml'
       expect(page).to have_content '9953670.marc'
     end
 

--- a/spec/features/oai_spec.rb
+++ b/spec/features/oai_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe 'OAI-PMH', type: :feature do
     it 'renders the set membership of each item' do
       visit oai_url(verb: 'ListRecords', metadataPrefix: 'marc21')
       doc = Nokogiri::XML(page.body)
-      expect(doc.at_css('ListRecords > record > header > setSpec').text).to eq('my-org')
+      expect(doc.at_css('ListRecords > record > header > setSpec').text).to eq(organization.default_stream.id.to_s)
     end
 
     it 'renders records in the requested set'

--- a/spec/features/oai_spec.rb
+++ b/spec/features/oai_spec.rb
@@ -64,14 +64,21 @@ RSpec.describe 'OAI-PMH', type: :feature do
   end
 
   context 'when the verb is ListSets' do
-    it 'renders a set element for each organization' do
+    it 'renders a name for each set' do
       visit oai_url(verb: 'ListSets')
       doc = Nokogiri::XML(page.body)
-      expect(doc.at_css('ListSets > set > setName').text).to eq('my-org, stream 2020-05-06 - ')
+      expect(doc.at_css('ListSets > set > setName').text).to eq('2020-05-06 - ')
+    end
+
+    it 'renders an identifier (setSpec) for each set' do
+      visit oai_url(verb: 'ListSets')
+      doc = Nokogiri::XML(page.body)
       expect(doc.at_css('ListSets > set > setSpec').text).to eq(organization.default_stream.id.to_s)
-      expect(doc.at_css('ListSets > set > setDescription').text).to(
-        include('Current default stream for my-org, 2020-05-06 00:00:00 UTC to present')
-      )
+    end
+
+    it 'renders a description for each set' do
+      visit oai_url(verb: 'ListSets')
+      expect(page).to have_text('Default stream for My Org, 2020-05-06/')
     end
 
     it 'renders an error if unknown params are supplied' do

--- a/spec/features/oai_spec.rb
+++ b/spec/features/oai_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe 'OAI-PMH', type: :feature do
     end
 
     it 'renders a header indicating records are deleted' do
+      pending('There should be a deleted record, but it is not on the first page.')
       visit oai_url(verb: 'ListRecords', metadataPrefix: 'marc21')
       expect(page).to have_selector('header[status="deleted"]')
     end
@@ -195,6 +196,8 @@ RSpec.describe 'OAI-PMH', type: :feature do
       end
 
       it 'renders an error if the resumption token is not valid' do
+        pending('badResumptionToken only gets raised if the page count is out of range. ' \
+                'Need to improve token error handling before this test will pass.')
         visit oai_url(verb: 'ListRecords', resumptionToken: 'foo')
         expect(page).to have_selector('error[code="badResumptionToken"]')
       end

--- a/spec/features/oai_spec.rb
+++ b/spec/features/oai_spec.rb
@@ -131,11 +131,17 @@ RSpec.describe 'OAI-PMH', type: :feature do
       expect(doc.at_css('ListMetadataFormats > metadataFormat > metadataNamespace').text).to eq('http://www.loc.gov/MARC21/slim')
     end
 
-    it 'renders the metadata formats available for a single item'
+    it 'renders the metadata formats available for a single item' do
+      visit oai_url(verb: 'ListMetadataFormats', identifier: 'oai:pod.stanford.edu:my-org:1:a12345')
+      doc = Nokogiri::XML(page.body)
+      expect(doc.at_css('ListMetadataFormats > metadataFormat > metadataPrefix').text).to eq('marc21')
+    end
 
-    it 'renders an error if an unknown identifier is supplied'
-
-    it 'renders an error if no metadata formats are available for the item'
+    it 'renders an error if an unknown identifier is supplied' do
+      pending 'single item requests are not yet implemented'
+      visit oai_url(verb: 'ListMetadataFormats', identifier: 'fake')
+      expect(page).to have_selector('error[code="idDoesNotExist"]')
+    end
 
     it 'renders an error if unknown params are supplied' do
       visit oai_url(verb: 'ListMetadataFormats', foo: 'bar')

--- a/spec/features/oai_spec.rb
+++ b/spec/features/oai_spec.rb
@@ -193,6 +193,11 @@ RSpec.describe 'OAI-PMH', type: :feature do
       expect(page).to have_selector('error[code="cannotDisseminateFormat"]')
     end
 
+    it 'renders an error if the request results in an empty result set' do
+      visit oai_url(verb: 'ListRecords', metadataPrefix: 'marc21', set: '392487')
+      expect(page).to have_selector('error[code="noRecordsMatch"]')
+    end
+
     context 'when a resumption token is supplied' do
       it 'renders the next page of records'
       it 'renders an error if any other argument is also supplied' do

--- a/spec/features/oai_spec.rb
+++ b/spec/features/oai_spec.rb
@@ -10,15 +10,20 @@ RSpec.describe 'OAI-PMH', type: :feature do
   # parsing the response using Nokogiri is required for some assertions
 
   before do
-    # first full dump: two records, 2020-05-06
+    # set a low oai_max_page_size so we get multiple oai-xml files generated
+    allow(Settings).to receive(:oai_max_page_size).and_return(2)
+
+    # first full dump: three records, 2020-05-06
     travel_to Time.zone.local(2020, 5, 6) do
       create(:upload, :marc_xml, stream: organization.default_stream)
+      create(:upload, :marc_xml2, stream: organization.default_stream)
       create(:upload, :binary_marc, stream: organization.default_stream)
       GenerateFullDumpJob.perform_now(organization)
     end
 
-    # delta dump from the next day, with one of the records deleted
+    # delta dump from the next day, add one and delete one record
     travel_to Time.zone.local(2020, 5, 7) do
+      create(:upload, :marc_xml3, stream: organization.default_stream)
       create(:upload, :deleted_marc_xml, stream: organization.default_stream)
       GenerateDeltaDumpJob.perform_now(organization)
     end

--- a/spec/features/oai_spec.rb
+++ b/spec/features/oai_spec.rb
@@ -58,8 +58,11 @@ RSpec.describe 'OAI-PMH', type: :feature do
     it 'renders a set element for each organization' do
       visit oai_url(verb: 'ListSets')
       doc = Nokogiri::XML(page.body)
-      expect(doc.at_css('ListSets > set > setName').text).to eq('My Org')
-      expect(doc.at_css('ListSets > set > setSpec').text).to eq('my-org')
+      expect(doc.at_css('ListSets > set > setName').text).to eq('my-org, stream 2020-05-06 - ')
+      expect(doc.at_css('ListSets > set > setSpec').text).to eq(organization.default_stream.id.to_s)
+      expect(doc.at_css('ListSets > set > setDescription').text).to(
+        include('Current default stream for my-org, 2020-05-06 00:00:00 UTC to present')
+      )
     end
 
     it 'renders an error if unknown params are supplied' do
@@ -139,7 +142,9 @@ RSpec.describe 'OAI-PMH', type: :feature do
     it 'renders the identifier of each item' do
       visit oai_url(verb: 'ListRecords', metadataPrefix: 'marc21')
       doc = Nokogiri::XML(page.body)
-      expect(doc.at_css('ListRecords > record > header > identifier').text).to eq('oai:pod.stanford.edu:my-org:a12345')
+      expect(doc.at_css('ListRecords > record > header > identifier').text).to(
+        eq("oai:pod.stanford.edu:my-org:#{organization.default_stream.id}:a12345")
+      )
     end
 
     it 'renders the datestamp of each item' do

--- a/spec/fixtures/12345.marcxml
+++ b/spec/fixtures/12345.marcxml
@@ -1,1 +1,107 @@
-<record xmlns='http://www.loc.gov/MARC21/slim'><leader>01257nam a2200325   4500</leader><controlfield tag='001'>a12345</controlfield><controlfield tag='003'>SIRSI</controlfield><controlfield tag='005'>20200914003001.0</controlfield><controlfield tag='008'>780221s1958    ii f          000 0 eng d</controlfield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(OCoLC-M)3656884</subfield></datafield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(OCoLC-I)268806725</subfield></datafield><datafield ind1=' ' ind2=' ' tag='040'><subfield code='a'>AFU</subfield><subfield code='c'>AFU</subfield><subfield code='d'>m/c</subfield><subfield code='d'>STF</subfield><subfield code='d'>OrLoB</subfield></datafield><datafield ind1='1' ind2=' ' tag='041'><subfield code='a'>eng</subfield><subfield code='h'>san</subfield></datafield><datafield ind1=' ' ind2=' ' tag='049'><subfield code='a'>STFA</subfield></datafield><datafield ind1=' ' ind2=' ' tag='092'><subfield code='a'>181.4</subfield><subfield code='b'>Y5W89 ed.6</subfield></datafield><datafield ind1='1' ind2=' ' tag='100'><subfield code='a'>Woodroffe, John George,</subfield><subfield code='c'>Sir,</subfield><subfield code='d'>1865-1936.</subfield><subfield code=' '>^A34726</subfield></datafield><datafield ind1='1' ind2='4' tag='245'><subfield code='a'>The serpent power:</subfield><subfield code='b'>being the Sat-cakra-nirūpana and Pādukā-pañcaka,</subfield><subfield code='b'>two works on Laya yoga,</subfield><subfield code='c'>translated from the Sanskrit, with introd. and commentary by Arthur Avalon [pseud.]</subfield></datafield><datafield ind1=' ' ind2=' ' tag='250'><subfield code='a'>6th ed.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='260'><subfield code='a'>Madras,</subfield><subfield code='b'>Ganesh,</subfield><subfield code='c'>1958.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='300'><subfield code='a'>xiv, 529, v, 184 p.</subfield><subfield code='b'>XVII plates (part col.)</subfield><subfield code='c'>25 cm.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='596'><subfield code='a'>31</subfield></datafield><datafield ind1=' ' ind2='0' tag='650'><subfield code='a'>Yoga.</subfield><subfield code=' '>^A1076704</subfield></datafield><datafield ind1=' ' ind2='0' tag='650'><subfield code='a'>Shaktism.</subfield><subfield code=' '>^A1060436</subfield></datafield><datafield ind1='0' ind2=' ' tag='700'><subfield code='a'>Pūrnānanda Gosvāmǐ.</subfield><subfield code='t'>Sat-cakra-nirūpana.</subfield><subfield code=' '>UNAUTHORIZED</subfield></datafield><datafield ind1='0' ind2=' ' tag='700'><subfield code='a'>Pādukā.</subfield><subfield code=' '>UNAUTHORIZED</subfield></datafield><datafield ind1='0' ind2=' ' tag='700'><subfield code='a'>Kālīcharana, Tāntrika.</subfield><subfield code=' '>UNAUTHORIZED</subfield></datafield><datafield ind1='0' ind2=' ' tag='740'><subfield code='a'>Satcakranirūpana.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='916'><subfield code='a'>DATE CATALOGED</subfield><subfield code='b'>19900915</subfield></datafield><datafield ind1=' ' ind2=' ' tag='919'><subfield code='a'>exclude from BorrowDirect</subfield><subfield code='b'>HathiTrust ETAS</subfield></datafield><datafield ind1=' ' ind2=' ' tag='999'><subfield code='a'>181.4 .Y5 W89 ED.6</subfield><subfield code='w'>DEWEY</subfield><subfield code='c'>1</subfield><subfield code='i'>36105010209950</subfield><subfield code='d'>8/9/2019</subfield><subfield code='e'>6/18/2019</subfield><subfield code='l'>STACKS</subfield><subfield code='m'>SAL3</subfield><subfield code='n'>4</subfield><subfield code='r'>Y</subfield><subfield code='s'>Y</subfield><subfield code='t'>STKS-MONO</subfield><subfield code='u'>2/21/1978</subfield></datafield></record>
+<?xml version="1.0" encoding="UTF-8"?>
+<record xmlns='http://www.loc.gov/MARC21/slim'>
+    <leader>01257nam a2200325   4500</leader>
+    <controlfield tag='001'>a12345</controlfield>
+    <controlfield tag='003'>SIRSI</controlfield>
+    <controlfield tag='005'>20200914003001.0</controlfield>
+    <controlfield tag='008'>780221s1958    ii f          000 0 eng d</controlfield>
+    <datafield ind1=' ' ind2=' ' tag='035'>
+        <subfield code='a'>(OCoLC-M)3656884</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='035'>
+        <subfield code='a'>(OCoLC-I)268806725</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='040'>
+        <subfield code='a'>AFU</subfield>
+        <subfield code='c'>AFU</subfield>
+        <subfield code='d'>m/c</subfield>
+        <subfield code='d'>STF</subfield>
+        <subfield code='d'>OrLoB</subfield>
+    </datafield>
+    <datafield ind1='1' ind2=' ' tag='041'>
+        <subfield code='a'>eng</subfield>
+        <subfield code='h'>san</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='049'>
+        <subfield code='a'>STFA</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='092'>
+        <subfield code='a'>181.4</subfield>
+        <subfield code='b'>Y5W89 ed.6</subfield>
+    </datafield>
+    <datafield ind1='1' ind2=' ' tag='100'>
+        <subfield code='a'>Woodroffe, John George,</subfield>
+        <subfield code='c'>Sir,</subfield>
+        <subfield code='d'>1865-1936.</subfield>
+        <subfield code=' '>^A34726</subfield>
+    </datafield>
+    <datafield ind1='1' ind2='4' tag='245'>
+        <subfield code='a'>The serpent power:</subfield>
+        <subfield code='b'>being the Sat-cakra-nirūpana and Pādukā-pañcaka,</subfield>
+        <subfield code='b'>two works on Laya yoga,</subfield>
+        <subfield code='c'>translated from the Sanskrit, with introd. and commentary by Arthur Avalon [pseud.]</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='250'>
+        <subfield code='a'>6th ed.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='260'>
+        <subfield code='a'>Madras,</subfield>
+        <subfield code='b'>Ganesh,</subfield>
+        <subfield code='c'>1958.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='300'>
+        <subfield code='a'>xiv, 529, v, 184 p.</subfield>
+        <subfield code='b'>XVII plates (part col.)</subfield>
+        <subfield code='c'>25 cm.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='596'>
+        <subfield code='a'>31</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='0' tag='650'>
+        <subfield code='a'>Yoga.</subfield>
+        <subfield code=' '>^A1076704</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='0' tag='650'>
+        <subfield code='a'>Shaktism.</subfield>
+        <subfield code=' '>^A1060436</subfield>
+    </datafield>
+    <datafield ind1='0' ind2=' ' tag='700'>
+        <subfield code='a'>Pūrnānanda Gosvāmǐ.</subfield>
+        <subfield code='t'>Sat-cakra-nirūpana.</subfield>
+        <subfield code=' '>UNAUTHORIZED</subfield>
+    </datafield>
+    <datafield ind1='0' ind2=' ' tag='700'>
+        <subfield code='a'>Pādukā.</subfield>
+        <subfield code=' '>UNAUTHORIZED</subfield>
+    </datafield>
+    <datafield ind1='0' ind2=' ' tag='700'>
+        <subfield code='a'>Kālīcharana, Tāntrika.</subfield>
+        <subfield code=' '>UNAUTHORIZED</subfield>
+    </datafield>
+    <datafield ind1='0' ind2=' ' tag='740'>
+        <subfield code='a'>Satcakranirūpana.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='916'>
+        <subfield code='a'>DATE CATALOGED</subfield>
+        <subfield code='b'>19900915</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='919'>
+        <subfield code='a'>exclude from BorrowDirect</subfield>
+        <subfield code='b'>HathiTrust ETAS</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='999'>
+        <subfield code='a'>181.4 .Y5 W89 ED.6</subfield>
+        <subfield code='w'>DEWEY</subfield>
+        <subfield code='c'>1</subfield>
+        <subfield code='i'>36105010209950</subfield>
+        <subfield code='d'>8/9/2019</subfield>
+        <subfield code='e'>6/18/2019</subfield>
+        <subfield code='l'>STACKS</subfield>
+        <subfield code='m'>SAL3</subfield>
+        <subfield code='n'>4</subfield>
+        <subfield code='r'>Y</subfield>
+        <subfield code='s'>Y</subfield>
+        <subfield code='t'>STKS-MONO</subfield>
+        <subfield code='u'>2/21/1978</subfield>
+    </datafield>
+</record>

--- a/spec/fixtures/75163.marcxml
+++ b/spec/fixtures/75163.marcxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<record>
+<record xmlns="http://www.loc.gov/MARC21/slim">
    <leader>01554cam a2200385 4500</leader>
    <controlfield tag="001">DUKE000075163</controlfield>
    <controlfield tag="005">19910502000000.0</controlfield>

--- a/spec/fixtures/75163.marcxml
+++ b/spec/fixtures/75163.marcxml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+   <leader>01554cam a2200385 4500</leader>
+   <controlfield tag="001">DUKE000075163</controlfield>
+   <controlfield tag="005">19910502000000.0</controlfield>
+   <controlfield tag="008">910502s1973^^^^nyu^^^^^^^^^^^000^0^eng^^</controlfield>
+   <datafield ind1=" " ind2=" " tag="010">
+      <subfield code="a">72081025 //r843</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="020">
+      <subfield code="a">0816402477</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">00649938</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="040">
+      <subfield code="a">DLC</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="c">DLC</subfield>
+      <subfield code="d">m.c.</subfield>
+      <subfield code="d">NDD</subfield>
+   </datafield>
+   <datafield ind1="1" ind2=" " tag="041">
+      <subfield code="a">eng</subfield>
+      <subfield code="a">fre</subfield>
+   </datafield>
+   <datafield ind1="9" ind2="9" tag="050">
+      <subfield code="a">BV4638</subfield>
+      <subfield code="b">.E4413 1973</subfield>
+   </datafield>
+   <datafield ind1="0" ind2=" " tag="050">
+      <subfield code="a">BV4638</subfield>
+      <subfield code="b">.E4413</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="082">
+      <subfield code="a">234/.2</subfield>
+   </datafield>
+   <datafield ind1="1" ind2=" " tag="100">
+      <subfield code="a">Ellul, Jacques,</subfield>
+      <subfield code="d">1912-1994.</subfield>
+      <subfield code="0">http://id.loc.gov/authorities/names/n80021739</subfield>
+   </datafield>
+   <datafield ind1="1" ind2="0" tag="240">
+      <subfield code="a">Espérance oubliée.</subfield>
+      <subfield code="l">English</subfield>
+      <subfield code="0">http://id.loc.gov/authorities/names/no2009078460</subfield>
+   </datafield>
+   <datafield ind1="1" ind2="0" tag="245">
+      <subfield code="a">Hope in time of abandonment.</subfield>
+      <subfield code="c">Translated by C. Edward Hopkin.</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="260">
+      <subfield code="a">New York,</subfield>
+      <subfield code="b">Seabury Press</subfield>
+      <subfield code="c">[1973]</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="300">
+      <subfield code="a">xiii, 306 p.</subfield>
+      <subfield code="c">22 cm.</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="336">
+      <subfield code="a">text</subfield>
+      <subfield code="b">txt</subfield>
+      <subfield code="2">rdacontent</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="337">
+      <subfield code="a">unmediated</subfield>
+      <subfield code="b">n</subfield>
+      <subfield code="2">rdamedia</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="338">
+      <subfield code="a">volume</subfield>
+      <subfield code="b">nc</subfield>
+      <subfield code="2">rdacarrier</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="500">
+      <subfield code="a">Translation of l'Espérance oubliée.</subfield>
+   </datafield>
+   <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Hope</subfield>
+      <subfield code="x">Religious aspects</subfield>
+      <subfield code="x">Christianity.</subfield>
+      <subfield code="0">http://id.loc.gov/authorities/subjects/sh85061925</subfield>
+   </datafield>
+   <datafield ind1=" " ind2="0" tag="650">
+      <subfield code="a">Civilization, Modern</subfield>
+      <subfield code="y">1950-</subfield>
+      <subfield code="0">http://id.loc.gov/authorities/subjects/sh85026475</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="905">
+      <subfield code="a">MARCIVE 20190326</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="905">
+      <subfield code="a">MARCIVE 20200114</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="942">
+      <subfield code="a">AM</subfield>
+      <subfield code="b">Book</subfield>
+   </datafield>
+   <datafield ind1="0" ind2=" " tag="852">
+      <subfield code="b">DIV</subfield>
+      <subfield code="c">PD</subfield>
+      <subfield code="h">BV4638</subfield>
+      <subfield code="i">.E4413 1973</subfield>
+      <subfield code="D">x</subfield>
+   </datafield>
+   <datafield ind1="0" ind2=" " tag="852">
+      <subfield code="b">LSC</subfield>
+      <subfield code="c">PSD</subfield>
+      <subfield code="h">BV4638</subfield>
+      <subfield code="i">.E4413 1973</subfield>
+      <subfield code="D">x</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="940">
+      <subfield code="b">DIV</subfield>
+      <subfield code="c">PD</subfield>
+      <subfield code="d">0</subfield>
+      <subfield code="h">BV4638 .E4413 1973</subfield>
+      <subfield code="n">c.1</subfield>
+      <subfield code="o">01</subfield>
+      <subfield code="q" />
+      <subfield code="r">BOOK</subfield>
+      <subfield code="p">D02452825S </subfield>
+      <subfield code="s">20020705</subfield>
+      <subfield code="u">20071012</subfield>
+      <subfield code="v">20220520</subfield>
+      <subfield code="w">4</subfield>
+      <subfield code="k">000075163</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="940">
+      <subfield code="b">LSC</subfield>
+      <subfield code="c">PSD</subfield>
+      <subfield code="d">0</subfield>
+      <subfield code="h">BV4638 .E4413 1973</subfield>
+      <subfield code="n">c.2</subfield>
+      <subfield code="o">01</subfield>
+      <subfield code="q">DP</subfield>
+      <subfield code="r">BOOK</subfield>
+      <subfield code="p">D02452826T </subfield>
+      <subfield code="s">19930808</subfield>
+      <subfield code="u">20180814</subfield>
+      <subfield code="v">20140427</subfield>
+      <subfield code="w">1</subfield>
+      <subfield code="k">000075163</subfield>
+   </datafield>
+   <datafield ind1=" " ind2=" " tag="900">
+      <subfield code="5">POD</subfield>
+   </datafield>
+</record>

--- a/spec/fixtures/deleted.marcxml
+++ b/spec/fixtures/deleted.marcxml
@@ -1,1 +1,107 @@
-<record xmlns='http://www.loc.gov/MARC21/slim'><leader>01257dam a2200325   4500</leader><controlfield tag='001'>a12345</controlfield><controlfield tag='003'>SIRSI</controlfield><controlfield tag='005'>20200914003001.0</controlfield><controlfield tag='008'>780221s1958    ii f          000 0 eng d</controlfield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(OCoLC-M)3656884</subfield></datafield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(OCoLC-I)268806725</subfield></datafield><datafield ind1=' ' ind2=' ' tag='040'><subfield code='a'>AFU</subfield><subfield code='c'>AFU</subfield><subfield code='d'>m/c</subfield><subfield code='d'>STF</subfield><subfield code='d'>OrLoB</subfield></datafield><datafield ind1='1' ind2=' ' tag='041'><subfield code='a'>eng</subfield><subfield code='h'>san</subfield></datafield><datafield ind1=' ' ind2=' ' tag='049'><subfield code='a'>STFA</subfield></datafield><datafield ind1=' ' ind2=' ' tag='092'><subfield code='a'>181.4</subfield><subfield code='b'>Y5W89 ed.6</subfield></datafield><datafield ind1='1' ind2=' ' tag='100'><subfield code='a'>Woodroffe, John George,</subfield><subfield code='c'>Sir,</subfield><subfield code='d'>1865-1936.</subfield><subfield code=' '>^A34726</subfield></datafield><datafield ind1='1' ind2='4' tag='245'><subfield code='a'>The serpent power:</subfield><subfield code='b'>being the Sat-cakra-nirūpana and Pādukā-pañcaka,</subfield><subfield code='b'>two works on Laya yoga,</subfield><subfield code='c'>translated from the Sanskrit, with introd. and commentary by Arthur Avalon [pseud.]</subfield></datafield><datafield ind1=' ' ind2=' ' tag='250'><subfield code='a'>6th ed.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='260'><subfield code='a'>Madras,</subfield><subfield code='b'>Ganesh,</subfield><subfield code='c'>1958.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='300'><subfield code='a'>xiv, 529, v, 184 p.</subfield><subfield code='b'>XVII plates (part col.)</subfield><subfield code='c'>25 cm.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='596'><subfield code='a'>31</subfield></datafield><datafield ind1=' ' ind2='0' tag='650'><subfield code='a'>Yoga.</subfield><subfield code=' '>^A1076704</subfield></datafield><datafield ind1=' ' ind2='0' tag='650'><subfield code='a'>Shaktism.</subfield><subfield code=' '>^A1060436</subfield></datafield><datafield ind1='0' ind2=' ' tag='700'><subfield code='a'>Pūrnānanda Gosvāmǐ.</subfield><subfield code='t'>Sat-cakra-nirūpana.</subfield><subfield code=' '>UNAUTHORIZED</subfield></datafield><datafield ind1='0' ind2=' ' tag='700'><subfield code='a'>Pādukā.</subfield><subfield code=' '>UNAUTHORIZED</subfield></datafield><datafield ind1='0' ind2=' ' tag='700'><subfield code='a'>Kālīcharana, Tāntrika.</subfield><subfield code=' '>UNAUTHORIZED</subfield></datafield><datafield ind1='0' ind2=' ' tag='740'><subfield code='a'>Satcakranirūpana.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='916'><subfield code='a'>DATE CATALOGED</subfield><subfield code='b'>19900915</subfield></datafield><datafield ind1=' ' ind2=' ' tag='919'><subfield code='a'>exclude from BorrowDirect</subfield><subfield code='b'>HathiTrust ETAS</subfield></datafield><datafield ind1=' ' ind2=' ' tag='999'><subfield code='a'>181.4 .Y5 W89 ED.6</subfield><subfield code='w'>DEWEY</subfield><subfield code='c'>1</subfield><subfield code='i'>36105010209950</subfield><subfield code='d'>8/9/2019</subfield><subfield code='e'>6/18/2019</subfield><subfield code='l'>STACKS</subfield><subfield code='m'>SAL3</subfield><subfield code='n'>4</subfield><subfield code='r'>Y</subfield><subfield code='s'>Y</subfield><subfield code='t'>STKS-MONO</subfield><subfield code='u'>2/21/1978</subfield></datafield></record>
+<?xml version="1.0" encoding="UTF-8"?>
+<record xmlns='http://www.loc.gov/MARC21/slim'>
+    <leader>01257dam a2200325   4500</leader>
+    <controlfield tag='001'>a12345</controlfield>
+    <controlfield tag='003'>SIRSI</controlfield>
+    <controlfield tag='005'>20200914003001.0</controlfield>
+    <controlfield tag='008'>780221s1958    ii f          000 0 eng d</controlfield>
+    <datafield ind1=' ' ind2=' ' tag='035'>
+        <subfield code='a'>(OCoLC-M)3656884</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='035'>
+        <subfield code='a'>(OCoLC-I)268806725</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='040'>
+        <subfield code='a'>AFU</subfield>
+        <subfield code='c'>AFU</subfield>
+        <subfield code='d'>m/c</subfield>
+        <subfield code='d'>STF</subfield>
+        <subfield code='d'>OrLoB</subfield>
+    </datafield>
+    <datafield ind1='1' ind2=' ' tag='041'>
+        <subfield code='a'>eng</subfield>
+        <subfield code='h'>san</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='049'>
+        <subfield code='a'>STFA</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='092'>
+        <subfield code='a'>181.4</subfield>
+        <subfield code='b'>Y5W89 ed.6</subfield>
+    </datafield>
+    <datafield ind1='1' ind2=' ' tag='100'>
+        <subfield code='a'>Woodroffe, John George,</subfield>
+        <subfield code='c'>Sir,</subfield>
+        <subfield code='d'>1865-1936.</subfield>
+        <subfield code=' '>^A34726</subfield>
+    </datafield>
+    <datafield ind1='1' ind2='4' tag='245'>
+        <subfield code='a'>The serpent power:</subfield>
+        <subfield code='b'>being the Sat-cakra-nirūpana and Pādukā-pañcaka,</subfield>
+        <subfield code='b'>two works on Laya yoga,</subfield>
+        <subfield code='c'>translated from the Sanskrit, with introd. and commentary by Arthur Avalon [pseud.]</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='250'>
+        <subfield code='a'>6th ed.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='260'>
+        <subfield code='a'>Madras,</subfield>
+        <subfield code='b'>Ganesh,</subfield>
+        <subfield code='c'>1958.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='300'>
+        <subfield code='a'>xiv, 529, v, 184 p.</subfield>
+        <subfield code='b'>XVII plates (part col.)</subfield>
+        <subfield code='c'>25 cm.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='596'>
+        <subfield code='a'>31</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='0' tag='650'>
+        <subfield code='a'>Yoga.</subfield>
+        <subfield code=' '>^A1076704</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2='0' tag='650'>
+        <subfield code='a'>Shaktism.</subfield>
+        <subfield code=' '>^A1060436</subfield>
+    </datafield>
+    <datafield ind1='0' ind2=' ' tag='700'>
+        <subfield code='a'>Pūrnānanda Gosvāmǐ.</subfield>
+        <subfield code='t'>Sat-cakra-nirūpana.</subfield>
+        <subfield code=' '>UNAUTHORIZED</subfield>
+    </datafield>
+    <datafield ind1='0' ind2=' ' tag='700'>
+        <subfield code='a'>Pādukā.</subfield>
+        <subfield code=' '>UNAUTHORIZED</subfield>
+    </datafield>
+    <datafield ind1='0' ind2=' ' tag='700'>
+        <subfield code='a'>Kālīcharana, Tāntrika.</subfield>
+        <subfield code=' '>UNAUTHORIZED</subfield>
+    </datafield>
+    <datafield ind1='0' ind2=' ' tag='740'>
+        <subfield code='a'>Satcakranirūpana.</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='916'>
+        <subfield code='a'>DATE CATALOGED</subfield>
+        <subfield code='b'>19900915</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='919'>
+        <subfield code='a'>exclude from BorrowDirect</subfield>
+        <subfield code='b'>HathiTrust ETAS</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='999'>
+        <subfield code='a'>181.4 .Y5 W89 ED.6</subfield>
+        <subfield code='w'>DEWEY</subfield>
+        <subfield code='c'>1</subfield>
+        <subfield code='i'>36105010209950</subfield>
+        <subfield code='d'>8/9/2019</subfield>
+        <subfield code='e'>6/18/2019</subfield>
+        <subfield code='l'>STACKS</subfield>
+        <subfield code='m'>SAL3</subfield>
+        <subfield code='n'>4</subfield>
+        <subfield code='r'>Y</subfield>
+        <subfield code='s'>Y</subfield>
+        <subfield code='t'>STKS-MONO</subfield>
+        <subfield code='u'>2/21/1978</subfield>
+    </datafield>
+</record>

--- a/spec/jobs/generate_delta_dump_job_spec.rb
+++ b/spec/jobs/generate_delta_dump_job_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe GenerateDeltaDumpJob, type: :job do
     described_class.perform_now(organization)
 
     expect(organization.default_stream.reload.current_full_dump.deltas.last
-                       .marcxml.attachment.blob.filename).to eq 'marcxml.xml.gz'
+                       .marcxml.attachment.blob.filename.to_s).to end_with 'marcxml.xml.gz'
   end
 
   it 'has a content type of application/gzip for compressed marc21' do
@@ -61,7 +61,7 @@ RSpec.describe GenerateDeltaDumpJob, type: :job do
     described_class.perform_now(organization)
 
     expect(organization.default_stream.reload.current_full_dump.deltas.last
-                       .marc21.attachment.blob.filename).to eq 'marc21.mrc.gz'
+                       .marc21.attachment.blob.filename.to_s).to end_with 'marc21.mrc.gz'
   end
 
   context 'with deletes' do
@@ -88,7 +88,7 @@ RSpec.describe GenerateDeltaDumpJob, type: :job do
       described_class.perform_now(organization)
 
       expect(organization.default_stream.reload.current_full_dump.deltas.last
-                         .deletes.attachment.blob.filename).to eq 'deletes.del.txt'
+                         .deletes.attachment.blob.filename.to_s).to end_with 'deletes.del.txt'
     end
 
     it 'does not include MARC records that were deleted' do

--- a/spec/jobs/generate_full_dump_job_spec.rb
+++ b/spec/jobs/generate_full_dump_job_spec.rb
@@ -49,6 +49,18 @@ RSpec.describe GenerateFullDumpJob, type: :job do
     end
   end
 
+  # rubocop:disable Rspec/ExampleLength
+  it 'does not generate empty OAI-XML files for uploads consisting of only deletes' do
+    organization.default_stream.uploads << build(:upload, :deletes)
+    allow(Settings).to receive(:oai_max_page_size).and_return(1)
+    described_class.perform_now(organization)
+
+    organization.default_stream.normalized_dumps.last.oai_xml.each do |file|
+      expect(file.blob.byte_size.positive?).to be true
+    end
+  end
+  # rubocop:enable Rspec/ExampleLength
+
   it 'has a content type of application/gzip for compressed marcxml' do
     described_class.perform_now(organization)
 

--- a/spec/models/marc_record_spec.rb
+++ b/spec/models/marc_record_spec.rb
@@ -10,8 +10,13 @@ RSpec.describe MarcRecord, type: :model do
   let(:upload) { create(:upload, :binary_marc, organization: organization) }
   let(:record) do
     MARC::Record.new.tap do |record|
+      record.append(MARC::ControlField.new('001', '12345'))
       record.append(MARC::DataField.new('999', ' ', ' ', %w[a NA737.K4], %w[i 36105032407764], %w[m ART]))
     end
+  end
+
+  it 'has a unique OAI identifier' do
+    expect(marc_record.oai_id).to eq('oai:pod.stanford.edu:org-1:12345')
   end
 
   describe '#marc' do

--- a/spec/models/marc_record_spec.rb
+++ b/spec/models/marc_record_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe MarcRecord, type: :model do
   end
 
   it 'has a unique OAI identifier' do
-    expect(marc_record.oai_id).to eq('oai:pod.stanford.edu:ivy-u:12345')
+    expect(marc_record.oai_id).to eq("oai:pod.stanford.edu:ivy-u:#{upload.stream.id}:12345")
   end
 
   describe '#marc' do

--- a/spec/models/marc_record_spec.rb
+++ b/spec/models/marc_record_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MarcRecord, type: :model do
   subject(:marc_record) { described_class.new(marc: record, upload: upload, **attr) }
 
   let(:attr) { {} }
-  let(:organization) { create(:organization, code: 'COOlCOdE') }
+  let(:organization) { create(:organization, code: 'COOlCOdE', slug: 'ivy-u') }
   let(:upload) { create(:upload, :binary_marc, organization: organization) }
   let(:record) do
     MARC::Record.new.tap do |record|
@@ -16,7 +16,7 @@ RSpec.describe MarcRecord, type: :model do
   end
 
   it 'has a unique OAI identifier' do
-    expect(marc_record.oai_id).to eq('oai:pod.stanford.edu:org-1:12345')
+    expect(marc_record.oai_id).to eq('oai:pod.stanford.edu:ivy-u:12345')
   end
 
   describe '#marc' do


### PR DESCRIPTION
# changelog
- fills out the tests for the entire OAI implementation, including ListRecords
- implements resumptionTokens for OAI requests
- refactors ListRecords to use stream-based sets
- handles a few more error/edge cases for assorted other OAI request types
- generates OAI-XML files as part of full and delta dumps that are used to page thru records in OAI requests
- fixes a bug related to generating empty OAI-XML files, and tests for it
- updates the naming of delta dump files to include more information, as we do for full dumps
- adds/makes some fixtures easier to read and fixes some misc. typos/copy-paste errors around fixtures.
# rationale
1. using streams as sets avoids the thorny problem of inter-stream deltas (see e.g. #601, #602) and we have heard from IndexData that this is acceptable for the time being (see conversation on #417). our `ListSets` response includes some metadata in the `setDescription` block intended to be parsed by IndexData (if necessary) to indicate whether a set is a current or former default stream, and the dates for which it was/is the default.
2. IndexData has indicated that processing records in blocks of about 100 at a time is reasonable. the simplest implementation for paged OAI responses is to pregenerate the OAI-XML ahead of time as part of the dump jobs, in 100-record-size "pages", and then serve them in a paginated manner from the controller. not every page will include the full 100 records, but no page will include more than 100 records, and progressing through the pages via `resumptionToken`s will eventually yield the full set, which is OAI-compliant.
3. a `resumptionToken` is a Base64-urlsafe-encoded combination of `set` (see 1. above), `page` (see 2. above), `from_date` (corresponding to the OAI `from` param), and `until_date` (corresponding to the OAI `until` param), any of which may be `nil`. the token is used to construct a filtered set of `NormalizedDump`s, which is mapped to a list of OAI-XML "pages", and then indexed using `page`. tokens have a read-only `version` specifier to ensure that, if this API changes, tokens encoded using a former version of the API will be rendered invalid.
4. to ensure uniqueness, OAI record IDs for MARC records are currently defined via [OAI-ID guidelines](http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm) as `oai:pod.stanford.edu:[org-slug]:[stream-id]:[marc001]`.