### PR TITLE
Remove make default button from stream show page. Closes #810

### DIFF
--- a/app/views/streams/_header.html.erb
+++ b/app/views/streams/_header.html.erb
@@ -12,9 +12,3 @@
     <%= link_to t('.reanalyze'), reanalyze_organization_stream_path(stream.organization, stream), method: :post, class: 'btn btn-secondary align-self-center' if can?(:manage, stream) %>
   </div>
 </div>
-
-<div class="mb-3">
-  <% unless stream.default? %>
-    <%= link_to t('.make_default'), make_default_organization_streams_path(stream.organization, stream: stream.slug), method: :post, class: 'btn btn-secondary align-self-center' if can?(:update, stream) %>
-  <% end %>
-</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,7 +159,6 @@ en:
       title: Manage users
   streams:
     header:
-      make_default: Make default
       manage_streams: Manage streams
       reanalyze: Re-analyze
       upload: New upload


### PR DESCRIPTION
Streams can be made default from the manage streams page.