### PR TITLE
oai identify response

### DIFF
--- a/app/controllers/concerns/oai_concern.rb
+++ b/app/controllers/concerns/oai_concern.rb
@@ -123,5 +123,16 @@ module OaiConcern
         'xsi:schemaLocation' => 'http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd'
       }
     end
+
+    # XML namespace values for OAI Identifier schema
+    # Used for the Identify description, see:
+    # http://www.openarchives.org/OAI/openarchivesprotocol.html#Identify
+    def oai_id_xmlns
+      {
+        'xmlns' => 'http://www.openarchives.org/OAI/2.0/oai-identifier/',
+        'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+        'xsi:schemaLocation' => 'http://www.openarchives.org/OAI/2.0/oai-identifier http://www.openarchives.org/OAI/2.0/oai-identifier.xsd'
+      }
+    end
   end
 end

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -233,6 +233,8 @@ class OaiController < ApplicationController
   # rubocop:enable Metrics/MethodLength
 
   # See https://www.openarchives.org/OAI/openarchivesprotocol.html#Identify
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def build_identify_response(earliest_date)
     Nokogiri::XML::Builder.new do |xml|
       build_oai_response xml, identify_params do
@@ -240,14 +242,24 @@ class OaiController < ApplicationController
           xml.repositoryName t('layouts.application.title')
           xml.baseURL oai_url
           xml.protocolVersion '2.0'
+          xml.adminEmail Settings.contact_email
           xml.earliestDatestamp earliest_date.strftime('%F')
           xml.deletedRecord 'transient'
           xml.granularity 'YYYY-MM-DD'
-          xml.adminEmail Settings.contact_email
+          xml.description do
+            xml.send :'oai-identifier', oai_id_xmlns do
+              xml.scheme 'oai'
+              xml.repositoryIdentifier Settings.oai_repository_id
+              xml.delimiter ':'
+              xml.sampleIdentifier "oai:#{Settings.oai_repository_id}:stanford:1:12345"
+            end
+          end
         end
       end
     end.to_xml
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   # See http://www.openarchives.org/OAI/openarchivesprotocol.html#ListMetadataFormats
   def build_list_metadata_formats_response

--- a/app/models/marc_record.rb
+++ b/app/models/marc_record.rb
@@ -23,7 +23,7 @@ class MarcRecord < ApplicationRecord
 
   # See http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm
   def oai_id
-    "oai:pod.stanford.edu:#{organization.slug}:#{stream.id}:#{marc001}"
+    "oai:#{Settings.oai_repository_id}:#{organization.slug}:#{stream.id}:#{marc001}"
   end
 
   def augmented_marc

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,3 +54,6 @@ metadata_status:
 
 # max. MARC records per OAI-XML file; also max. size of one page in ListRecords
 oai_max_page_size: 500
+
+# base ID of the repository used to generate OAI IDs for records
+oai_repository_id: 'pod.stanford.edu'


### PR DESCRIPTION
- Extract OAI repository ID to settings
- Update OAI Identify response

The validator at http://oval.base-search.net/ seemed to not like the order in which we presented our elements in the `Identify` response. Hard to imagine this is in violation of the spec, but I reordered them and also added a `description` as recommended by the spec that illustrates how we are generating OAI IDs for records. The base OAI ID for the whole aggregator is now controlled by a config setting.