### PR TITLE
Hide file status legend from screenreaders

### DIFF
--- a/app/views/dashboard/summary.html.erb
+++ b/app/views/dashboard/summary.html.erb
@@ -43,7 +43,7 @@
 
   <!-- Upload activity table -->
   <h2 class="mt-5"><%= t('.upload_title') %></h2>
-  <ul class="table-key list-unstyled list-inline pt-3">
+  <ul class="table-key list-unstyled list-inline pt-3" aria-hidden="true">
     <% Settings.metadata_status.each do |status, values| %>
     <li class="list-inline-item">
       <%= bootstrap_icon(values.icon_class, class: "pod-metadata-status #{status}") %>
@@ -70,7 +70,7 @@
       <tr>
         <td class="text-center">
           <%= bootstrap_icon(Settings.metadata_status[file.pod_metadata_status].icon_class, class: "pod-metadata-status #{file.pod_metadata_status}") %>
-          <span class="visually-hidden"><%= file.pod_metadata_status %></span>
+          <span class="visually-hidden">Type of file: <%= file.pod_metadata_status %></span>
         </td>
         <td>
           <%= link_to_if can?(:read, upload), upload.name, organization_upload_path(upload.organization, upload), title: t('.table.upload_title', name: upload.name) %>

--- a/app/views/uploads/_file_rows.html.erb
+++ b/app/views/uploads/_file_rows.html.erb
@@ -15,7 +15,7 @@
   <tr>
     <td class="align-middle text-center">
       <%= bootstrap_icon(Settings.metadata_status[file.pod_metadata_status].icon_class, class: "pod-metadata-status #{file.pod_metadata_status}") %>
-      <span class="visually-hidden"><%= file.pod_metadata_status %></span>
+      <span class="visually-hidden">Type of file: <%= file.pod_metadata_status %></span>
     </td> 
     <td class="align-middle">
       <%= link_to_if can?(:read, upload), file.filename, download_url(file), title: "Download #{file.filename}" %>

--- a/app/views/uploads/_file_table.html.erb
+++ b/app/views/uploads/_file_table.html.erb
@@ -1,4 +1,4 @@
-<ul class="table-key list-unstyled list-inline pt-3">
+<ul class="table-key list-unstyled list-inline pt-3" aria-hidden="true">
   <% Settings.metadata_status.each do |status, values| %>
   <li class="list-inline-item">
     <%= bootstrap_icon(values.icon_class, class: "pod-metadata-status #{status}") %>


### PR DESCRIPTION
The file status legend we use for the uploaded files table in a couple of places isn't necessary for screenreaders, since its intent is a visual reference to the "Status" column icons in the table below.

This PR:

- Removes the legend from the accessibility tree so it won't be read
- Adds the text "Type of file:" before the visually hidden icon status value. This results in the screenreader saying "Type of file: unknown" or "Type of file: valid" when reading the first column of the table, rather than just "valid" or "unknown".

<img width="1137" alt="Screen Shot 2022-06-01 at 4 48 44 PM" src="https://user-images.githubusercontent.com/101482/171520301-1ebd9a4c-2667-40bb-a058-db5bb26274be.png">


(Ideally we should read the complete status value shown in the legend ("Valid MARC (adds, updates, or deletes")) but that seems more complicated than I want to try to do in this PR so I'll create a separate ticket for it.)