### PR TITLE
Hide 'Status' column from screenreaders on Processing status page

### DIFF
--- a/app/views/streams/_job_status.html.erb
+++ b/app/views/streams/_job_status.html.erb
@@ -28,7 +28,7 @@
               <table class="table table-striped mt-4">
                 <thead>
                   <tr>
-                    <th class="text-center"><%= t('job_tracker.table_heading.status') %></th>
+                    <th class="text-center" aria-hidden="true"><%= t('job_tracker.table_heading.status') %></th>
                     <th><%= t('job_tracker.table_heading.resource') %></th>
                     <th><%= t('job_tracker.table_heading.job_type') %></th>
                     <th class="text-end"><%= t('job_tracker.table_heading.progress') %></th>
@@ -37,7 +37,7 @@
                 </thead>
                 <% jobs.sort_by(&:created_at).reverse.each do |job| %>
                   <tr class="<%= "status-#{job.job_id}" %>">
-                    <td class="text-center">
+                    <td class="text-center" aria-hidden="true">
                       <%= bootstrap_icon(Settings.job_status_group[status_group].icon_class, class: "pod-icon pod-job-tracker-status #{job.sidekiq_status}")%>
                     </td>
                     <td><%= job.resource_label %></td>


### PR DESCRIPTION
On the organization Processing status page we show jobs that fit into the "Active" and "Needs attention" categories in separate expand/collapse sections. To reinforce the status of the jobs in each section, the first column in the table of jobs is "Status" and we show the appropriate icon. But because of this separated status organization, every job in the table for a given section has the same status; for a screenreader user the visual reinforcement doesn't apply and hearing the repeated description of each icon in the table is unnecessary and slows down the process of navigating the table.


<img width="1189" alt="Screen Shot 2022-06-02 at 10 36 30 AM" src="https://user-images.githubusercontent.com/101482/171692606-bb7fee48-2ce5-4470-af0c-f95793623848.png">


So this PR just removes from the accessibility tree the Status heading and icon column from the tables -- on the Processing status page only.

