### PR TITLE
Replace the stream summary box with more responsive code

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,7 @@
 @import 'pod-icons';
 @import 'rails_bootstrap_forms';
 @import 'organizations';
+@import 'streams';
 
 // background image for homepage banner
 #hero .bg-image {

--- a/app/assets/stylesheets/streams.scss
+++ b/app/assets/stylesheets/streams.scss
@@ -1,0 +1,60 @@
+.stream-metadata-box { 
+  border-radius: 0 0 0.33rem 0.33rem;
+  display: grid;
+  align-items: center;
+  grid-template-areas: 
+    "box-header box-header"
+    "files filesize"
+    "records unique";
+  grid-template-rows: 1fr 1.1fr 1.1fr;  
+  grid-template-columns: 1fr 1fr;
+  grid-row-gap: 3px;
+  grid-column-gap: 5px;
+  height: 100%;
+  margin: 0;
+}  
+
+// Stack the layout on small devices/viewports
+@media all and (max-width: 500px) {
+  .stream-metadata-box { 
+    grid-template-areas: 
+      "box-header"
+      "files"
+      "filesize"
+      "records"
+      "unique";
+    grid-template-rows: 1fr 1fr 1fr 1fr 1fr;
+    grid-template-columns: 1fr;
+    justify-items: left;
+    
+    .box-metadata {
+      padding-left: 1rem;
+    }
+  }
+}
+
+#box-header {
+  background-color: #495057;
+  font-size: 0.85rem;
+  grid-area: box-header;
+}
+
+#box-files { 
+  grid-area: files;      
+}
+
+#box-filesize { 
+  grid-area: filesize;      
+}
+
+#box-records { 
+  grid-area: records;      
+}
+
+#box-unique-records { 
+  grid-area: unique;      
+}
+
+.box-metadata {
+  padding-right: 1rem;
+}

--- a/app/views/streams/_summary_card.html.erb
+++ b/app/views/streams/_summary_card.html.erb
@@ -1,22 +1,20 @@
-<div class="card col-12 col-md-8 offset-md-2 col-lg-6 offset-lg-3 col-xxl-4 offset-xxl-4 mb-3">
-    <div class="card-body bg-light">
-        <div class="row text-center">
-            <p class="lead mb-1">
-                <% stream_updated = stream.uploads.last&.updated_at || stream.updated_at %>
-                Last updated: <%= content_tag :span, "#{time_ago_in_words(stream_updated)} ago", title: local_time(stream_updated, format: datetime_display_format()) %>
-            </p>
-            <span class="border-bottom mt-1 mb-3"></span>
-          </div>
-        <div class="row mt-3">
-            <div class="col">
-                <p>Files: <span class="fw-bold"><%= number_with_delimiter stream.statistic&.file_count || 0 %></span></p>
-                <p class="mb-0">Total file size: <span class="fw-bold"><%= number_to_human_size stream.statistic&.file_size || 0 %></span></p>
-            </div>
-
-            <div class="col">
-                <p>Records: <span class="fw-bold"><%= number_with_delimiter stream.statistic&.record_count || 0 %></span></p>
-                <p class="mb-0">Unique records: <span class="fw-bold"><%= number_with_delimiter stream.statistic&.unique_record_count || 0 %></span></p>
-            </div>
-        </div>
+<div class="d-flex justify-content-center mt-3 mb-2">
+  <div class="stream-metadata-box bg-light border border-bg-secondary text-center">
+    <div id="box-header" class="text-light py-1 px-4 text-uppercase fw-bolder">
+      <% stream_updated = stream.uploads.last&.updated_at || stream.updated_at %>
+          Stream updated: <%= content_tag :span, "#{time_ago_in_words(stream_updated)} ago", title: local_time(stream_updated, format: datetime_display_format()) %>
     </div>
+    <div id="box-files" class="box-metadata">Files:
+      <span class="fw-bold"><%= number_with_delimiter stream.statistic&.file_count || 0 %></span>
+    </div>
+    <div id="box-filesize" class="box-metadata">Total file size:
+      <span class="fw-bold"><%= number_to_human_size stream.statistic&.file_size || 0 %></span>
+    </div>
+    <div id="box-records" class="box-metadata">Records:
+      <span class="fw-bold"><%= number_with_delimiter stream.statistic&.record_count || 0 %></span>
+    </div>
+    <div id="box-unique-records" class="box-metadata">Unique records:
+      <span class="fw-bold"><%= number_with_delimiter stream.statistic&.unique_record_count || 0 %></span>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
The summary box on the Provider home pages is a little awkward in that it's hard to get the ideal width of the box at different viewports widths. It also isn't great visually: it takes up more vertical height than it really needs to.

<img width="1342" alt="Screen Shot 2022-06-03 at 3 38 12 PM" src="https://user-images.githubusercontent.com/101482/171965092-f593c4d5-d6ae-45e9-b776-b5094d555bc8.png">



This PR replaces the existing code, which is based on Bootstrap's Card component, and uses CSS Grid instead. The CSS is kind of verbose but this enables us to display a box in a consistent width at desktop viewports, and break the rows of metadata into new lines when at small viewports. This approach is also more compact and I think gives a stronger emphasis to the box.

## After: Desktop
<img width="999" alt="Screen Shot 2022-06-03 at 3 36 41 PM" src="https://user-images.githubusercontent.com/101482/171964968-b2f92ec0-69f7-4b83-bb4c-f0026b3f72d3.png">

---

## After: Small mobile
(Nothing looks great here, but presumably users would not be using POD on a phone on any kind of regular basis...)

<img width="486" alt="Screen Shot 2022-06-03 at 3 37 27 PM" src="https://user-images.githubusercontent.com/101482/171964985-44c97983-a9b0-4222-b297-73331c314c22.png">

---

