### PR TITLE
Add vertical spacing to header and adjust header display size

### DIFF
--- a/app/views/dashboard/summary.html.erb
+++ b/app/views/dashboard/summary.html.erb
@@ -6,7 +6,7 @@
     <h2><%= t('.summary_title') %></h2>
 
     <!-- Activity summary tabs -->
-    <ul class="nav nav-tabs" id="summary-tabs" role="tablist">
+    <ul class="nav nav-tabs mt-3" id="summary-tabs" role="tablist">
       <li class="nav-item" role="presentation">
         <button class="nav-link active" id="uploads-tab" data-bs-toggle="tab" data-bs-target="#uploads-pane" type="button"
           role="tab" aria-controls="uploads-pane" aria-selected="true">Uploads</button>

--- a/app/views/site_users/index.html.erb
+++ b/app/views/site_users/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container index-page">
-  <h1><%= t('.title') %></h1>
+  <h1 class="h2"><%= t('.title') %></h1>
   <table class="table table-striped mt-4">
     <thead>
       <tr>


### PR DESCRIPTION
Super minor styling things:

- Adjusted display size of Users page header to match main headers on all other pages
- Added some vertical spacing between the "Activity summary" heading and the tab group below it, to more closely match the usual vertical space that follows page headers:

<img width="1014" alt="Screen Shot 2022-06-03 at 4 28 44 PM" src="https://user-images.githubusercontent.com/101482/171966698-5a664729-8a01-497a-8dbb-c398745e0209.png">

