### PR TITLE
Do not run full dump job every 3 months

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -27,7 +27,6 @@ every :day do
 end
 
 every 3.months do
-  runner 'GenerateFullDumpJob.enqueue_all'
   runner 'CleanupAndRemoveDataJob.enqueue_all'
 end
 


### PR DESCRIPTION
I'd like to start these full dump jobs manually for the moment. Once we have the jobs running correctly, it could be something that we kick off automatically after a stream is made the default (TBD).