### PR TITLE
skip_authorize_resource for resourcelist requests; fixes 406 error

### DIFF
--- a/app/controllers/streams_controller.rb
+++ b/app/controllers/streams_controller.rb
@@ -4,7 +4,7 @@
 class StreamsController < ApplicationController
   load_and_authorize_resource :organization
   load_and_authorize_resource through: :organization, except: %i[make_default]
-  skip_authorize_resource only: %i[normalized_dump]
+  skip_authorize_resource only: %i[normalized_dump resourcelist]
   protect_from_forgery with: :null_session, if: :jwt_token
 
   def show
@@ -12,6 +12,7 @@ class StreamsController < ApplicationController
   end
 
   def resourcelist
+    authorize! :read, @stream
     show
     render 'show'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
   get 'dashboard/summary', to: 'dashboard#summary', as: :activity
   get 'charts/uploads', to: 'charts#uploads', as: :uploads_chart
   get 'charts/records', to: 'charts#records', as: :records_chart
-  
+
   get '/data', to: 'pages#data'
 
   # disable default /edit path for organizations in favor of organization_details and provider_details
@@ -59,7 +59,7 @@ Rails.application.routes.draw do
 
     get 'invite/new', to: 'organization_invitations#new'
     post 'invite', to: 'organization_invitations#create'
-    
+
     resources :streams, only: [:index, :destroy, :show, :create, :new] do
       collection do
         post 'make_default'


### PR DESCRIPTION
closes #871 

With this change:
```
aggregator % curl -H "Authorization: Bearer $TOKEN" --url http://localhost:3000/organizations/test/streams/a3a791a5-bb97-455c-9ce2-6cdff375863a/resourcelist 
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:rs="http://www.openarchives.org/rs/terms/">
  <rs:ln rel="up" href="http://localhost:3000/organizations/resourcelist"/>
  <rs:md capability="resourcelist" at="2022-06-13T00:49:15Z"/>
  <url>
    <rs:md hash="md5:92a59f13d864f13419c1d3108012eee7" type="application/marc" length="10146917"/>
    <loc>http://localhost:3000/file/1/pod_220606_uni_increment.marc</loc>
    <lastmod>2022-06-13T00:48:59Z</lastmod>
  </url>
</urlset>
```