### PR TITLE
Restyle the summary box for File show page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@
 @import 'rails_bootstrap_forms';
 @import 'organizations';
 @import 'streams';
+@import 'files';
 
 // background image for homepage banner
 #hero .bg-image {

--- a/app/assets/stylesheets/files.scss
+++ b/app/assets/stylesheets/files.scss
@@ -1,0 +1,47 @@
+.file-metadata-box { 
+  border-radius: 0 0 0.33rem 0.33rem;
+  display: grid;
+  align-items: center;
+  grid-template-areas: 
+    "box-header box-header"
+    "filesize records"
+    "stream stream"
+    "upload upload";
+  grid-template-rows: 1fr;  
+  grid-template-columns: 1fr 1fr;
+  grid-row-gap: 8px;
+  grid-column-gap: 5px;
+  justify-items: left;
+  height: 100%;
+  margin: 0;
+
+  .box-metadata {
+    padding-left: 1rem;
+  }
+}  
+
+#file-box-header {
+  background-color: #495057;
+  font-size: 0.85rem;
+  grid-area: box-header;
+}
+
+#file-box-filesize { 
+  grid-area: filesize;      
+}
+
+#file-box-records { 
+  grid-area: records;      
+}
+
+#file-box-stream { 
+  grid-area: stream;      
+}
+
+#file-box-upload { 
+  grid-area: upload;      
+}
+
+.box-metadata {
+  padding-right: 1rem;
+}

--- a/app/views/uploads/_summary_card.html.erb
+++ b/app/views/uploads/_summary_card.html.erb
@@ -1,20 +1,19 @@
-<div class="card col-12 col-md-8 offset-md-2 col-lg-6 offset-lg-3 col-xxl-4 offset-xxl-4 mb-3 mt-3">
-    <div class="card-body bg-light">
-        <div class="row text-center">
-            <p class="lead mb-1">
-                Created: <%= local_time(@upload.created_at, format: datetime_display_format) %>
-            </p>
-            <span class="border-bottom mt-1 mb-3"></span>
-        </div>
-        <div class="row mt-3">
-            <div class="col">
-                <p>Size: <span class="fw-bold"><%= number_to_human_size @blob.byte_size %></p> 
-            </div>
-            <div class="col">
-                <p>Records: <span class="fw-bold"><%= number_with_delimiter @blob.metadata['count'] || 0 %></span></p>
-            </div>
-        </div>
-        <p>Part of stream: <%= link_to @upload.stream.display_name, organization_stream_path(@upload.organization, @upload.stream) %></p>
-        <p>Part of upload: <%= link_to @upload.name, organization_upload_path(@upload.organization, @upload) %></p>
+<div class="d-flex justify-content-center my-3">
+  <div class="file-metadata-box bg-light border border-bg-secondary text-center pb-3">
+    <div id="file-box-header" class="text-light mb-1 py-1 px-4 text-uppercase fw-bolder">File created:
+      <%= local_time(@upload.created_at, format: datetime_display_format) %>
     </div>
+    <div id="file-box-filesize" class="box-metadata">Size:
+      <span class="fw-bold"><%= number_to_human_size @blob.byte_size %></span>
+    </div>
+    <div id="file-box-records" class="box-metadata">Records:
+      <span class="fw-bold"><%= number_with_delimiter @blob.metadata['count'] || 0 %></span>
+    </div>
+    <div id="file-box-stream" class="box-metadata">Part of stream:
+      <%= link_to @upload.stream.display_name, organization_stream_path(@upload.organization, @upload.stream) %>
+    </div>
+    <div id="file-box-upload" class="box-metadata">Part of upload:
+      <%= link_to @upload.name, organization_upload_path(@upload.organization, @upload) %>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
I noticed that while I updated the styling of the summary box at the top of the Stream page, I didn't do anything to the very similar box we show on the File page. This PR follows the pattern for the Stream summary box to restyle the File summary box for better consistency. (There's probably a way to reduce duplicate SCSS between the two, but it felt like more effort than necessary at this point in the project.)

## Before

<img width="1170" alt="Screen Shot 2022-06-14 at 4 16 13 PM" src="https://user-images.githubusercontent.com/101482/173705047-b204b63b-a473-4465-9b1c-efffd3b844a5.png">


## After

<img width="1170" alt="Screen Shot 2022-06-14 at 4 15 17 PM" src="https://user-images.githubusercontent.com/101482/173705039-810a1101-c2ff-4251-8272-4d749d968ba8.png">

