### PR TITLE
Allow ExtractMarcRecordMetadataJob to fail if ActiveStorage::FileNotFound exception is raised

### DIFF
--- a/app/jobs/attach_remote_file_to_upload_job.rb
+++ b/app/jobs/attach_remote_file_to_upload_job.rb
@@ -9,6 +9,7 @@ class AttachRemoteFileToUploadJob < ApplicationJob
   def perform(upload)
     io = URI.parse(upload.url).open
     upload.files.attach(io: io, filename: filename_from_io(io) || filename_from_url(upload.url) || upload.name)
+    upload.update(status: 'active')
   rescue SocketError, OpenURI::HTTPError => e
     error = "Error opening #{upload.url}: #{e}"
     Rails.logger.info(error)

--- a/app/jobs/extract_marc_record_metadata_job.rb
+++ b/app/jobs/extract_marc_record_metadata_job.rb
@@ -7,7 +7,7 @@ class ExtractMarcRecordMetadataJob < ApplicationJob
 
   # rubocop:disable Metrics/AbcSize
   def perform(upload)
-    return unless upload.active?
+    return unless upload.active? && upload.files.any?
 
     progress.total = 0
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -40,6 +40,7 @@ class Upload < ApplicationRecord
     files.find_each(&:purge_later)
   end
 
+  # rubocop:disable Metrics/MethodLength
   def read_marc_record_metadata(**options, &block)
     return to_enum(:read_marc_record_metadata, **options) unless block
 
@@ -58,8 +59,10 @@ class Upload < ApplicationRecord
       end
     rescue StandardError => e
       Honeybadger.notify(e)
+      raise if e.instance_of?(ActiveStorage::FileNotFoundError)
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   private
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_24_194031) do
 ActiveRecord::Schema[7.0].define(version: 2022_06_09_120300) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
I tried checking for the existence of the blob in the `ExtractMarcRecordMetadataJob` (`file.blob.service.exist?(file.blob.key)`) to test the waters before proceeding, but it was not as reliable as allowing the exception from the `MarcRecordService`. 🤷 