### PR TITLE
Show default stream stats on org index view

### DIFF
--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -84,10 +84,10 @@
           <td class="align-middle">
             <%= link_to organization.name, organization %>
           </td>
-          <td class="align-middle text-end files-column"><%= organization.latest_statistics.file_count %></td>
-          <td class="align-middle text-end"><%= number_to_human_size organization.latest_statistics.file_size %></td>
-          <td class="align-middle text-end"><%= number_with_delimiter organization.latest_statistics.unique_record_count %></td>
-          <td class="align-middle text-end"><%= number_with_delimiter organization.latest_statistics.record_count %></td>
+          <td class="align-middle text-end files-column"><%= organization.default_stream&.statistic&.file_count || 0 %></td>
+          <td class="align-middle text-end"><%= number_to_human_size organization.default_stream&.statistic&.file_size || 0 %></td>
+          <td class="align-middle text-end"><%= number_with_delimiter organization.default_stream&.statistic&.unique_record_count || 0 %></td>
+          <td class="align-middle text-end"><%= number_with_delimiter organization.default_stream&.statistic&.record_count || 0 %></td>
           <td class="align-middle">
             <% if organization.default_stream.uploads.last&.created_at %>
               <%= local_time(organization.default_stream.uploads.last&.created_at, format: datetime_display_format()) %>


### PR DESCRIPTION
The organization statistics seem unreliable, sometimes displaying nothing. The org stats are also a mix of stats from all streams and the default stream, which is confusing. This PR will display the stats for the default stream until the issues with the org stats are resolved.