### PR TITLE
Use consistent ENV var for redis: SIDEKIQ_REDIS_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ One solution to this is to temporarily switch to using PostgreSQL and Sidekiq wi
 ```yaml
 development:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("SIDEKIQ_REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: aggregator_development
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ One solution to this is to temporarily switch to using PostgreSQL and Sidekiq wi
 ```yaml
 development:
   adapter: redis
-  url: <%= ENV.fetch("SIDEKIQ_REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("ACTION_CABLE_REDIS_URL") { "redis://localhost:6379/3" } %>
   channel_prefix: aggregator_development
 ```
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,7 +1,7 @@
 development:
-  <% if ENV.include? "SIDEKIQ_REDIS_URL" %>
+  <% if ENV.include? "ACTION_CABLE_REDIS_URL" %>
   adapter: redis
-  url: <%= ENV.fetch("SIDEKIQ_REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("ACTION_CABLE_REDIS_URL") { "redis://localhost:6379/3" } %>
   channel_prefix: aggregator_production
   <% else %>
   adapter: async
@@ -12,5 +12,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("SIDEKIQ_REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("ACTION_CABLE_REDIS_URL") { "redis://localhost:6379/3" } %>
   channel_prefix: aggregator_production

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,7 +1,7 @@
 development:
-  <% if ENV.include? "REDIS_URL" %>
+  <% if ENV.include? "SIDEKIQ_REDIS_URL" %>
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("SIDEKIQ_REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: aggregator_production
   <% else %>
   adapter: async
@@ -12,5 +12,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("SIDEKIQ_REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: aggregator_production

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   end
 
   # Use production-like ActiveJob backend (sidekiq) if Redis is available
-  config.active_job.queue_adapter = :sidekiq if ENV.include? 'REDIS_URL'
+  config.active_job.queue_adapter = :sidekiq if ENV.include? 'SIDEKIQ_REDIS_URL'
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_cache_store
+  config.cache_store = :redis_cache_store, { url: ENV.fetch("CACHE_REDIS_URL") { "redis://localhost:6379/2" } }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter     = :sidekiq

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -2,7 +2,7 @@
 
 OkComputer.mount_at = 'status'
 
-OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV.fetch('REDIS_URL') { 'redis://localhost:6379/1' })
+OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV.fetch('SIDEKIQ_REDIS_URL') { 'redis://localhost:6379/1' })
 
 # check activestorage by uploading + downloading a file
 class ActiveStorageCheck < OkComputer::Check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
     environment:
       RAILS_ENV: development
-      REDIS_URL: redis://aggcache:6379
+      SIDEKIQ_REDIS_URL: redis://aggcache:6379
       REDIS_HOST: aggcache
       REDIS_PORT: 6379
       DATABASE_URL: postgres://pod4lib:pod4lib@aggdb:5432/aggregator
@@ -26,7 +26,7 @@ services:
       dockerfile: Dockerfile
     command: bundle exec sidekiq
     environment:
-      REDIS_URL: redis://aggcache:6379
+      SIDEKIQ_REDIS_URL: redis://aggcache:6379
       DATABASE_URL: postgres://pod4lib:pod4lib@aggdb:5432/aggregator
       RAILS_MAX_THREADS: 5
     volumes:


### PR DESCRIPTION
We were using both `REDIS_URL` and `SIDEKIQ_REDIS_URL` in various places. Puppet is expecting `SIDEKIQ_REDIS_URL` when we switch from using a locally running Redis to one hosted on its own VM: https://github.com/sul-dlss/puppet/blob/production/hieradata/node/pod-prod.stanford.edu.eyaml#L63-L65