### PR TITLE
Change default redis db numbers to start at 0

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,7 +1,7 @@
 development:
   <% if ENV.include? "ACTION_CABLE_REDIS_URL" %>
   adapter: redis
-  url: <%= ENV.fetch("ACTION_CABLE_REDIS_URL") { "redis://localhost:6379/3" } %>
+  url: <%= ENV.fetch("ACTION_CABLE_REDIS_URL") { "redis://localhost:6379/2" } %>
   channel_prefix: aggregator_production
   <% else %>
   adapter: async
@@ -12,5 +12,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("ACTION_CABLE_REDIS_URL") { "redis://localhost:6379/3" } %>
+  url: <%= ENV.fetch("ACTION_CABLE_REDIS_URL") { "redis://localhost:6379/2" } %>
   channel_prefix: aggregator_production

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_cache_store, { url: ENV.fetch("CACHE_REDIS_URL") { "redis://localhost:6379/2" } }
+  config.cache_store = :redis_cache_store, { url: ENV.fetch("CACHE_REDIS_URL") { "redis://localhost:6379/1" } }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter     = :sidekiq

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -2,7 +2,7 @@
 
 OkComputer.mount_at = 'status'
 
-OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV.fetch('SIDEKIQ_REDIS_URL') { 'redis://localhost:6379/1' })
+OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV.fetch('SIDEKIQ_REDIS_URL') { 'redis://localhost:6379/0' })
 
 # check activestorage by uploading + downloading a file
 class ActiveStorageCheck < OkComputer::Check


### PR DESCRIPTION
In the currently released version of aggregator the sidekiq redis db would default to `/0` so it seems better to keep that as the default redis db number for sidekiq.