### PR TITLE
Need to pin the esm dist version of popper

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -3,8 +3,8 @@
 pin "application", preload: true
 pin "turbolinks", to: "https://ga.jspm.io/npm:turbolinks@5.2.0/dist/turbolinks.js"
 pin "@rails/activestorage", to: "https://ga.jspm.io/npm:@rails/activestorage@7.0.4-1/app/assets/javascripts/activestorage.esm.js"
-pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.2.3/dist/js/bootstrap.esm.js", preload: true
-pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.6/lib/index.js", preload: true
+pin "@popperjs/core", to: "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/esm/popper.min.js", preload: true
+pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.2.3/dist/js/bootstrap.esm.min.js", preload: true
 pin "chartkick", to: "chartkick.js"
 pin "Chart.bundle", to: "Chart.bundle.js"
 pin "local-time", to: "https://ga.jspm.io/npm:local-time@2.1.0/app/assets/javascripts/local-time.js"


### PR DESCRIPTION
Otherwise we get the error:
```
Uncaught ReferenceError: process is not defined
    setOptions createPopper.js:81
    createPopper createPopper.js:215
    _createPopper bootstrap.esm.js:4041
```


See https://github.com/twbs/bootstrap/issues/37978