### PR TITLE
Reduce how often update stats jobs are run

### DIFF
--- a/app/jobs/update_organization_statistics_job.rb
+++ b/app/jobs/update_organization_statistics_job.rb
@@ -8,14 +8,19 @@ class UpdateOrganizationStatisticsJob < ApplicationJob
     Organization.find_each { |o| perform_later(o) }
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def perform(organization, stream = nil, upload = nil)
     stream ||= organization.default_stream
 
     # short-circuit if our statstics job is already obsolete
     return if upload && stream.uploads.where('created_at > ?', upload.created_at).any?
 
+    # short-circuit if the stream's statistics have already been updated today
+    return if stream&.statistic&.updated_at&.today?
+
     generate_statistics!(organization, stream)
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def generate_statistics!(organization, stream)
     stream_statistics = stream.statistic || stream.create_statistic

--- a/app/jobs/update_organization_statistics_job.rb
+++ b/app/jobs/update_organization_statistics_job.rb
@@ -12,7 +12,7 @@ class UpdateOrganizationStatisticsJob < ApplicationJob
   def perform(organization, stream = nil, upload = nil)
     stream ||= organization.default_stream
 
-    # short-circuit if our statstics job is already obsolete
+    # short-circuit if our statistics job is already obsolete
     return if upload && stream.uploads.where('created_at > ?', upload.created_at).any?
 
     # short-circuit if the stream's statistics have already been updated today

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,9 +22,11 @@ job_type :runner,  "cd :path && :environment_variable=:environment bin/rails run
 
 # Learn more: http://github.com/javan/whenever
 
-every :day do
-  runner 'UpdateOrganizationStatisticsJob.perform_all'
-end
+# These jobs are expensive. Turning off this job for now
+# so stats update only when new files are uploaded.
+# every :day do
+#   runner 'UpdateOrganizationStatisticsJob.perform_all'
+# end
 
 every 3.months do
   runner 'CleanupAndRemoveDataJob.enqueue_all'


### PR DESCRIPTION
Many of these jobs are failing, take an hour or more to run, and get triggered multiple times per day. This PR:

- Turns off the cron job that runs the stats job once per day for each institution.
- Short circuits the job if the stats were already updated today.
- The net effect is is that stats only get updated if a new file is uploaded and then only once each day.