### PR TITLE
Run stats jobs once daily and not each time records are extracted from a file.

### DIFF
--- a/app/jobs/extract_marc_record_metadata_job.rb
+++ b/app/jobs/extract_marc_record_metadata_job.rb
@@ -28,8 +28,6 @@ class ExtractMarcRecordMetadataJob < ApplicationJob
 
       upload.update(status: 'processed', marc_records_count: total)
     end
-
-    UpdateOrganizationStatisticsJob.perform_later(upload.organization, upload.stream, upload)
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,11 +22,9 @@ job_type :runner,  "cd :path && :environment_variable=:environment bin/rails run
 
 # Learn more: http://github.com/javan/whenever
 
-# These jobs are expensive. Turning off this job for now
-# so stats update only when new files are uploaded.
-# every :day do
-#   runner 'UpdateOrganizationStatisticsJob.perform_all'
-# end
+every :day do
+  runner 'UpdateOrganizationStatisticsJob.perform_all'
+end
 
 every 3.months do
   runner 'CleanupAndRemoveDataJob.enqueue_all'

--- a/spec/jobs/extract_marc_record_metadata_job_spec.rb
+++ b/spec/jobs/extract_marc_record_metadata_job_spec.rb
@@ -15,12 +15,6 @@ RSpec.describe ExtractMarcRecordMetadataJob do
     expect(MarcRecord.last).to have_attributes marc001: 'a1297245', bytecount: 0, length: 1407, index: 0
   end
 
-  it 'enqueues the stats job' do
-    expect do
-      described_class.perform_now(upload)
-    end.to enqueue_job(UpdateOrganizationStatisticsJob)
-  end
-
   it 'tracks job statistics' do
     expect do
       described_class.perform_later(upload)


### PR DESCRIPTION
I want to see if we can get away with running this job once a day for each organization. Because Duke uploads about 50 files a day, running the expensive update stats job each time records are extracted from a file seems excessive.