### PR TITLE
Show the normalized files for the currently viewed stream

### DIFF
--- a/app/views/streams/normalized_data.html.erb
+++ b/app/views/streams/normalized_data.html.erb
@@ -13,5 +13,5 @@
     </div>
   </div>
 
-  <%= render 'streams/normalized_dump', normalized_dump: @organization.default_stream.normalized_dumps.full_dumps.published.last %>
+  <%= render 'streams/normalized_dump', normalized_dump: @stream.normalized_dumps.full_dumps.published.last %>
 <% end %>


### PR DESCRIPTION
Currently, the normalized dumps tab of any stream displays the list of normalized files attached to the current default stream. It should instead show any normalized files attached to the stream that is currently being viewed, whether or not it is the default.

As an example, this test stream with no uploads is displaying the list of normalized files for Princeton's default stream.

https://pod.stanford.edu/organizations/princeton/streams/princeton-test-set/normalized_data