### PR TITLE
Configure redis cache to reconnect

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_cache_store, { url: ENV.fetch("CACHE_REDIS_URL") { "redis://localhost:6379/1" } }
+  config.cache_store = :redis_cache_store, { url: ENV.fetch("CACHE_REDIS_URL") { "redis://localhost:6379/1" }, reconnect_attempts: 2 }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter     = :sidekiq


### PR DESCRIPTION
The rails default for reconnect-attempts is 0.

However on the main branch, they remove the default and it falls back to the Redis default (which is 2) https://github.com/rails/rails/commit/c8d8f09f56ffde6ecbb498cec8206fa5c72b8f49