### PR TITLE
Do not enqueue UpdateOrganizationStatisticsJob

### DIFF
--- a/app/jobs/extract_marc_record_metadata_job.rb
+++ b/app/jobs/extract_marc_record_metadata_job.rb
@@ -29,7 +29,9 @@ class ExtractMarcRecordMetadataJob < ApplicationJob
       upload.update(status: 'processed', marc_records_count: total)
     end
 
-    UpdateOrganizationStatisticsJob.perform_later(upload.organization, upload.stream, upload)
+    # For now, do no start an UpdateOrganizationStatisticsJob,
+    # until we resolve: https://github.com/pod4lib/aggregator/issues/975
+    # UpdateOrganizationStatisticsJob.perform_later(upload.organization, upload.stream, upload)
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/spec/jobs/extract_marc_record_metadata_job_spec.rb
+++ b/spec/jobs/extract_marc_record_metadata_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ExtractMarcRecordMetadataJob do
     expect(MarcRecord.last).to have_attributes marc001: 'a1297245', bytecount: 0, length: 1407, index: 0
   end
 
-  it 'enqueues the stats job' do
+  it 'enqueues the stats job', skip: 'until we resolve: https://github.com/pod4lib/aggregator/issues/975' do
     expect do
       described_class.perform_now(upload)
     end.to enqueue_job(UpdateOrganizationStatisticsJob)


### PR DESCRIPTION
These jobs are failing and restarting and clogging up sidekiq. Until we have time to investigate and resolve #975 let's not enqueue these jobs every time we extract MARC metadata from a file.