### PR TITLE
Specify that pages are HTML

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,7 +12,8 @@ class PagesController < ApplicationController
   def api; end
 
   def show
-    render template: "pages/#{params[:id]}"
+    render template: "pages/#{params[:id]}",
+           formats: :html # prevents ActionController::MissingExactTemplate triggered by Qualys scan
   end
 
   def data


### PR DESCRIPTION
This prevents Qualys scans from raising Honeybadger errors See https://app.honeybadger.io/projects/77305/faults/94599516