### PR TITLE
Stop testing on ruby 3.0 and 3.1 and add 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ruby: ['3.0', '3.1', '3.2']
+        ruby: ['3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
pod is now running in production on ruby 3.2