### PR TITLE
Set rubocop TargetRubyVersion to 3.2 and autocorrect

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   DisplayCopNames: true
   Exclude:
     - 'config.ru'

--- a/app/analyzers/marc_analyzer.rb
+++ b/app/analyzers/marc_analyzer.rb
@@ -8,10 +8,10 @@ class MarcAnalyzer < ActiveStorage::Analyzer
   end
 
   def metadata
-    metadata = { analyzer: self.class.to_s, count: count, type: type }
+    metadata = { analyzer: self.class.to_s, count:, type: }
     return metadata.merge(valid: false, error: 'No MARC records found') if count.zero?
 
-    MarcProfilingJob.perform_later(blob, count: count)
+    MarcProfilingJob.perform_later(blob, count:)
 
     metadata
   rescue MARC::XMLParseError, MARC::Exception => e

--- a/app/controllers/concerns/oai_concern.rb
+++ b/app/controllers/concerns/oai_concern.rb
@@ -71,7 +71,7 @@ module OaiConcern
       set, page, from_date, until_date, version = Base64.urlsafe_decode64(string).split(';')
       raise BadResumptionToken unless version == ResumptionToken.version
 
-      token = ResumptionToken.new(set: set, page: page, from_date: from_date, until_date: until_date)
+      token = ResumptionToken.new(set:, page:, from_date:, until_date:)
       raise BadResumptionToken unless token.valid?
 
       token

--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -15,7 +15,7 @@ class OaiController < ApplicationController
     raise OaiConcern::BadVerb
   end
 
-  def method_missing(method, *_args, &_block)
+  def method_missing(method, *_args, &)
     raise OaiConcern::BadVerb if method.to_s.start_with?('render_')
 
     super
@@ -265,7 +265,7 @@ class OaiController < ApplicationController
   def build_error_response(code, message, params = {})
     Nokogiri::XML::Builder.new do |xml|
       build_oai_response xml, params do
-        xml.error(code: code) do
+        xml.error(code:) do
           xml.text message
         end
       end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -73,7 +73,7 @@ class UploadsController < ApplicationController
       if params[:stream].present?
         slug = @organization.default_stream.normalize_friendly_id(params[:stream])
 
-        @organization.streams.find_or_create_by(slug: slug) do |stream|
+        @organization.streams.find_or_create_by(slug:) do |stream|
           stream.name = params[:stream]
         end
       else

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -36,11 +36,11 @@ module DashboardHelper
   end
 
   def any_successes?(statuses)
-    (%i[deletes success] & statuses).any?
+    %i[deletes success].intersect?(statuses)
   end
 
   def any_failures?(statuses)
-    (%i[invalid not_marc] & statuses).any?
+    %i[invalid not_marc].intersect?(statuses)
   end
 
   def count_roles(users)

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -19,7 +19,7 @@ class ApplicationJob < ActiveJob::Base
   private
 
   def find_or_initialize_job_tracker
-    JobTracker.find_or_create_by(job_id: job_id) do |tracker|
+    JobTracker.find_or_create_by(job_id:) do |tracker|
       tracker.job_class = self.class.name
       tracker.provider_job_id = provider_job_id
       update_job_tracker_properties(tracker)
@@ -31,6 +31,6 @@ class ApplicationJob < ActiveJob::Base
   end
 
   def cleanup_job_tracker
-    JobTracker.where(job_id: job_id).delete_all
+    JobTracker.where(job_id:).delete_all
   end
 end

--- a/app/jobs/attach_remote_file_to_upload_job.rb
+++ b/app/jobs/attach_remote_file_to_upload_job.rb
@@ -8,7 +8,7 @@ class AttachRemoteFileToUploadJob < ApplicationJob
 
   def perform(upload)
     io = URI.parse(upload.url).open
-    upload.files.attach(io: io, filename: filename_from_io(io) || filename_from_url(upload.url) || upload.name)
+    upload.files.attach(io:, filename: filename_from_io(io) || filename_from_url(upload.url) || upload.name)
     upload.update(status: 'active')
   rescue SocketError, OpenURI::HTTPError => e
     error = "Error opening #{upload.url}: #{e}"

--- a/app/jobs/extract_files_job.rb
+++ b/app/jobs/extract_files_job.rb
@@ -42,7 +42,7 @@ class ExtractFilesJob < ApplicationJob
   end
 
   def each_file(attachment, limit: 1000)
-    return to_enum(:each_file, attachment, limit: limit) unless block_given?
+    return to_enum(:each_file, attachment, limit:) unless block_given?
 
     counter = 0
 

--- a/app/models/allowlisted_jwt.rb
+++ b/app/models/allowlisted_jwt.rb
@@ -12,8 +12,8 @@ class AllowlistedJwt < ApplicationRecord
 
   def jwt_attributes
     {
-      jti: jti,
-      scope: scope,
+      jti:,
+      scope:,
       iss: 'POD',
       name: label
     }.compact_blank

--- a/app/models/job_tracker.rb
+++ b/app/models/job_tracker.rb
@@ -57,8 +57,8 @@ class JobTracker < ApplicationRecord
 
   private
 
-  def number_with_delimiter(*args)
-    ActiveSupport::NumberHelper.number_to_delimited(*args)
+  def number_with_delimiter(*)
+    ActiveSupport::NumberHelper.number_to_delimited(*)
   end
 
   def in_sidekiq_set?(set)

--- a/app/models/stream.rb
+++ b/app/models/stream.rb
@@ -87,7 +87,7 @@ class Stream < ApplicationRecord
     return if full_dump_id.blank?
 
     dumps_query = NormalizedDump.where(id: full_dump_id)
-                                .or(NormalizedDump.where(full_dump_id: full_dump_id))
+                                .or(NormalizedDump.where(full_dump_id:))
                                 .published
                                 .order(created_at: :asc)
     dumps_query = dumps_query.where('created_at >= ?', Time.zone.parse(from_date).beginning_of_day) if from_date.present?

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -43,8 +43,8 @@ class Upload < ApplicationRecord
   end
 
   # rubocop:disable Metrics/MethodLength
-  def read_marc_record_metadata(**options, &block)
-    return to_enum(:read_marc_record_metadata, **options) unless block
+  def read_marc_record_metadata(**, &block)
+    return to_enum(:read_marc_record_metadata, **) unless block
 
     files.each do |file|
       service = MarcRecordService.new(file.blob)
@@ -57,7 +57,7 @@ class Upload < ApplicationRecord
       when :unknown
         next
       else
-        extract_marc_record_metadata(file, service, **options, &block)
+        extract_marc_record_metadata(file, service, **, &block)
       end
     rescue StandardError => e
       Honeybadger.notify(e)
@@ -93,7 +93,7 @@ class Upload < ApplicationRecord
       tmpfile.each_line do |line|
         yield MarcRecord.new(
           marc001: line.strip,
-          file: file,
+          file:,
           upload: self,
           status: 'delete'
         )
@@ -102,12 +102,12 @@ class Upload < ApplicationRecord
   end
 
   def extract_marc_record_metadata(file, service, checksum: true)
-    return to_enum(:extract_marc_record_metadata, file, service, checksum: checksum) unless block_given?
+    return to_enum(:extract_marc_record_metadata, file, service, checksum:) unless block_given?
 
     service.each_with_metadata do |record, metadata|
       out = MarcRecord.new(
         **metadata,
-        file: file,
+        file:,
         marc: record,
         upload: self
       )

--- a/app/services/marc_record_service.rb
+++ b/app/services/marc_record_service.rb
@@ -97,7 +97,7 @@ class MarcRecordService
     return to_enum(:each_raw_record, reader) unless block_given?
 
     reader.each_with_index do |record, index|
-      with_honeybadger_context(index: index, marc001: record['001']&.value) do
+      with_honeybadger_context(index:, marc001: record['001']&.value) do
         yield record
       end
     end
@@ -140,10 +140,10 @@ class MarcRecordService
                          else identify
                          end
 
-        from_bytes(io.read(range.size), extracted_type, merge: merge)
+        from_bytes(io.read(range.size), extracted_type, merge:)
       end
     else
-      from_bytes(download_chunk(range), merge: merge)
+      from_bytes(download_chunk(range), merge:)
     end
   end
 
@@ -186,7 +186,7 @@ class MarcRecordService
 
     return each_with_metadata_for_marc21(&block) if marc21?
 
-    each.with_index { |record, index| yield record, extract_record_metadata(record).merge(index: index) }
+    each.with_index { |record, index| yield record, extract_record_metadata(record).merge(index:) }
   end
 
   private
@@ -227,7 +227,7 @@ class MarcRecordService
 
         yield record, {
           **records_to_combine.first.except(:marc, :marc_bytes),
-          index: index,
+          index:,
           length: bytes.length,
           checksum: Digest::MD5.hexdigest(bytes)
         }
@@ -241,15 +241,15 @@ class MarcRecordService
     with_reader do |reader|
       bytecount = 0
       reader.each_raw.with_index do |bytes, index|
-        with_honeybadger_context(bytecount: bytecount, index: index) do
+        with_honeybadger_context(bytecount:, index:) do
           length = bytes[0...5].to_i
           record = MARC::Reader.decode(bytes, external_encoding: 'UTF-8', invalid: :replace)
-          with_honeybadger_context(marc001: record['001']&.value, bytecount: bytecount, index: index) do
+          with_honeybadger_context(marc001: record['001']&.value, bytecount:, index:) do
             yield(
               extract_record_metadata(record).merge(
-                bytecount: bytecount,
-                length: length,
-                index: index,
+                bytecount:,
+                length:,
+                index:,
                 checksum: Digest::MD5.hexdigest(bytes),
                 marc_bytes: bytes,
                 marc: record

--- a/app/services/normalized_marc_record_reader.rb
+++ b/app/services/normalized_marc_record_reader.rb
@@ -15,7 +15,7 @@ class NormalizedMarcRecordReader
   end
 
   # @yield [MarcRecord]
-  def each(&block)
+  def each(&)
     pool = Concurrent::FixedThreadPool.new(thread_pool_size)
 
     current_marc_record_ids.each_slice(200) do |slice|
@@ -30,7 +30,7 @@ class NormalizedMarcRecordReader
         nil
       end
 
-      records.each(&block)
+      records.each(&)
     end
 
     pool.shutdown

--- a/app/views/organizations/index.xml.builder
+++ b/app/views/organizations/index.xml.builder
@@ -13,7 +13,7 @@ xml.sitemapindex(
            resourcesync_capabilitylist_url
          end
 
-  xml.tag!('rs:ln', rel: 'up', href: href)
+  xml.tag!('rs:ln', rel: 'up', href:)
   xml.tag!('rs:md', capability: 'resourcelist', at: Time.zone.now.iso8601)
   @organizations.each do |org|
     xml.sitemap do

--- a/lib/tasks/admin_tasks.rake
+++ b/lib/tasks/admin_tasks.rake
@@ -63,7 +63,7 @@ namespace :agg do
           puts "Uploading file #{file['filename']} (#{file['download_url']})"
           uri = URI.parse(file['download_url'])
           io = uri.open('Authorization' => "Bearer #{Settings.marc_fixture_seeds.token}")
-          upload.files.attach(io: io, filename: file['filename'])
+          upload.files.attach(io:, filename: file['filename'])
 
           upload_file_count += 1
           break if upload_file_count >= Settings.marc_fixture_seeds.file_count

--- a/spec/active_storage_blob_extensions/active_storage_blob_content_types_spec.rb
+++ b/spec/active_storage_blob_extensions/active_storage_blob_content_types_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ActiveStorageBlobContentTypes do
 
       def extract_metadata_via_analyzer
         {
-          content_type: content_type
+          content_type:
         }
       end
 

--- a/spec/factories/stream.rb
+++ b/spec/factories/stream.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     sequence(:name) { |n| "stream-#{n}" }
     factory :stream_with_uploads do
       after(:create) do |stream, options = { count: 1 }|
-        create_list(:upload, options[:count], :binary_marc, stream: stream)
+        create_list(:upload, options[:count], :binary_marc, stream:)
       end
     end
 

--- a/spec/features/normalized_download_spec.rb
+++ b/spec/features/normalized_download_spec.rb
@@ -4,15 +4,15 @@ require 'rails_helper'
 
 RSpec.describe 'Downloading normalized files from POD' do
   let(:organization) { create(:organization, code: 'best-org') }
-  let(:stream) { create(:stream, organization: organization, default: true) }
+  let(:stream) { create(:stream, organization:, default: true) }
   let(:user) { create(:user) }
 
   before do
     user.add_role :member, organization
     login_as(user, scope: :user)
 
-    create_list(:upload, 2, :binary_marc, organization: organization, stream: stream)
-    create_list(:upload, 2, :binary_marc_gz, organization: organization, stream: stream)
+    create_list(:upload, 2, :binary_marc, organization:, stream:)
+    create_list(:upload, 2, :binary_marc_gz, organization:, stream:)
   end
 
   describe 'Full dumps' do

--- a/spec/features/providers_spec.rb
+++ b/spec/features/providers_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Viewing provider information' do
 
   before do
     login_as(user, scope: :user)
-    create_list(:upload, 2, :binary_marc, organization: organization, stream: organization.default_stream)
+    create_list(:upload, 2, :binary_marc, organization:, stream: organization.default_stream)
   end
 
   describe 'Providers overview page as an unprivileged user' do

--- a/spec/features/unprivileged_user_spec.rb
+++ b/spec/features/unprivileged_user_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Downloading normalzed files from POD' do
   before do
     login_as(user, scope: :user)
 
-    create_list(:upload, 2, :binary_marc, organization: organization, stream: organization.default_stream)
+    create_list(:upload, 2, :binary_marc, organization:, stream: organization.default_stream)
   end
 
   it 'lists organizations' do

--- a/spec/features/upload_spec.rb
+++ b/spec/features/upload_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'uploading files to POD' do
   context 'with an organization user' do
     let(:organization) { create(:organization, name: 'Best University') }
-    let(:stream) { create(:stream, organization: organization) }
+    let(:stream) { create(:stream, organization:) }
     let(:user) { create(:user) }
 
     before do

--- a/spec/jobs/cleanup_and_remove_data_job_spec.rb
+++ b/spec/jobs/cleanup_and_remove_data_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CleanupAndRemoveDataJob do
     before do
       organization.default_stream
       Timecop.travel(4.months.ago)
-      create_list(:stream, 4, organization: organization)
+      create_list(:stream, 4, organization:)
       Timecop.return
     end
 
@@ -22,7 +22,7 @@ RSpec.describe CleanupAndRemoveDataJob do
     before do
       organization.default_stream
       Timecop.travel(7.months.ago)
-      create_list(:stream, 4, organization: organization, status: 'archived')
+      create_list(:stream, 4, organization:, status: 'archived')
       Timecop.return
     end
 

--- a/spec/jobs/generate_interstream_delta_job_spec.rb
+++ b/spec/jobs/generate_interstream_delta_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GenerateInterstreamDeltaJob do
   it 'Does not create an interstream delta if the current stream is missing a full dump' do
     GenerateFullDumpJob.perform_now(organization)
 
-    stream = create(:stream, organization: organization, default: true)
+    stream = create(:stream, organization:, default: true)
     stream.make_default
 
     described_class.perform_now(organization.default_stream)
@@ -31,7 +31,7 @@ RSpec.describe GenerateInterstreamDeltaJob do
   it 'Creates an interstream delta with proper additions and deletes' do
     GenerateFullDumpJob.perform_now(organization)
 
-    stream = create(:stream, organization: organization, default: false)
+    stream = create(:stream, organization:, default: false)
     organization.default_stream.default = false
     organization.default_stream.save
 

--- a/spec/mailers/contact_emails_mailer_spec.rb
+++ b/spec/mailers/contact_emails_mailer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ContactEmailsMailer do
   let(:contact_email) { build(:contact_email) }
 
   describe 'confirm_email' do
-    subject(:mail) { described_class.with(contact_email: contact_email).confirm_email }
+    subject(:mail) { described_class.with(contact_email:).confirm_email }
 
     it 'renders the headers' do
       expect(mail.subject).to eq('Confirm email')

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe Ability do
   describe 'with a user' do
     let(:organization) { create(:organization) }
     let(:not_my_org) { create(:organization) }
-    let(:default_stream) { create(:stream, :default, organization: organization) }
-    let(:previous_default_stream) { create(:stream, organization: organization) }
+    let(:default_stream) { create(:stream, :default, organization:) }
+    let(:previous_default_stream) { create(:stream, organization:) }
 
     context 'with an admin' do
       let(:user) { create(:admin) }
@@ -100,14 +100,14 @@ RSpec.describe Ability do
       it { is_expected.to be_able_to(:organization_details, organization) }
       it { is_expected.to be_able_to(:provider_details, organization) }
 
-      it { is_expected.to be_able_to(:crud, Upload.new(organization: organization)) }
-      it { is_expected.to be_able_to(:info, Upload.new(organization: organization)) }
+      it { is_expected.to be_able_to(:crud, Upload.new(organization:)) }
+      it { is_expected.to be_able_to(:info, Upload.new(organization:)) }
 
-      it { is_expected.to be_able_to(:crud, Stream.new(organization: organization)) }
-      it { is_expected.to be_able_to(:normalized_data, Stream.new(organization: organization)) }
-      it { is_expected.to be_able_to(:processing_status, Stream.new(organization: organization)) }
-      it { is_expected.to be_able_to(:profile, Stream.new(organization: organization)) }
-      it { is_expected.not_to be_able_to(:reanalyze, Stream.new(organization: organization)) }
+      it { is_expected.to be_able_to(:crud, Stream.new(organization:)) }
+      it { is_expected.to be_able_to(:normalized_data, Stream.new(organization:)) }
+      it { is_expected.to be_able_to(:processing_status, Stream.new(organization:)) }
+      it { is_expected.to be_able_to(:profile, Stream.new(organization:)) }
+      it { is_expected.not_to be_able_to(:reanalyze, Stream.new(organization:)) }
 
       it { is_expected.to be_able_to(:crud, AllowlistedJwt.new(resource: organization)) }
 
@@ -149,17 +149,17 @@ RSpec.describe Ability do
       it { is_expected.to be_able_to(:organization_details, organization) }
       it { is_expected.to be_able_to(:provider_details, organization) }
 
-      it { is_expected.to be_able_to(:read, Upload.new(organization: organization)) }
-      it { is_expected.to be_able_to(:info, Upload.new(organization: organization)) }
-      it { is_expected.to be_able_to(:create, Upload.new(organization: organization)) }
-      it { is_expected.not_to be_able_to(:destroy, Upload.new(organization: organization)) }
+      it { is_expected.to be_able_to(:read, Upload.new(organization:)) }
+      it { is_expected.to be_able_to(:info, Upload.new(organization:)) }
+      it { is_expected.to be_able_to(:create, Upload.new(organization:)) }
+      it { is_expected.not_to be_able_to(:destroy, Upload.new(organization:)) }
 
-      it { is_expected.to be_able_to(:read, Stream.new(organization: organization)) }
-      it { is_expected.to be_able_to(:normalized_data, Stream.new(organization: organization)) }
-      it { is_expected.to be_able_to(:processing_status, Stream.new(organization: organization)) }
-      it { is_expected.to be_able_to(:profile, Stream.new(organization: organization)) }
-      it { is_expected.not_to be_able_to(:create, Stream.new(organization: organization)) }
-      it { is_expected.not_to be_able_to(:reanalyze, Stream.new(organization: organization)) }
+      it { is_expected.to be_able_to(:read, Stream.new(organization:)) }
+      it { is_expected.to be_able_to(:normalized_data, Stream.new(organization:)) }
+      it { is_expected.to be_able_to(:processing_status, Stream.new(organization:)) }
+      it { is_expected.to be_able_to(:profile, Stream.new(organization:)) }
+      it { is_expected.not_to be_able_to(:create, Stream.new(organization:)) }
+      it { is_expected.not_to be_able_to(:reanalyze, Stream.new(organization:)) }
 
       it { is_expected.to be_able_to(:read, AllowlistedJwt.new(resource: organization)) }
       it { is_expected.not_to be_able_to(:create, AllowlistedJwt.new(resource: organization)) }

--- a/spec/models/contact_email_spec.rb
+++ b/spec/models/contact_email_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ContactEmail do
-  subject(:contact_email) { build(:contact_email, organization: organization) }
+  subject(:contact_email) { build(:contact_email, organization:) }
 
   let(:organization) { build(:organization) }
 

--- a/spec/models/job_tracker_spec.rb
+++ b/spec/models/job_tracker_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe JobTracker do
   subject(:job_tracker) do
     described_class.new(attributes.merge(job_class: 'whatever',
-                                         job_id: job_id,
-                                         provider_job_id: provider_job_id))
+                                         job_id:,
+                                         provider_job_id:))
   end
 
   let(:attributes) { {} }

--- a/spec/models/marc_profile_spec.rb
+++ b/spec/models/marc_profile_spec.rb
@@ -7,6 +7,6 @@ RSpec.describe MarcProfile do
   let(:blob) { upload.files.first.blob }
 
   it 'can be created without an upload' do
-    expect { described_class.create(blob: blob) }.to change(described_class, :count).by(1)
+    expect { described_class.create(blob:) }.to change(described_class, :count).by(1)
   end
 end

--- a/spec/models/marc_record_spec.rb
+++ b/spec/models/marc_record_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe MarcRecord do
-  subject(:marc_record) { described_class.new(marc: record, upload: upload, **attr) }
+  subject(:marc_record) { described_class.new(marc: record, upload:, **attr) }
 
   let(:attr) { {} }
   let(:organization) { create(:organization, code: 'COOlCOdE', slug: 'ivy-u') }
-  let(:upload) { create(:upload, :binary_marc, organization: organization) }
+  let(:upload) { create(:upload, :binary_marc, organization:) }
   let(:record) do
     MARC::Record.new.tap do |record|
       record.append(MARC::ControlField.new('001', '12345'))

--- a/spec/models/stream_spec.rb
+++ b/spec/models/stream_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Stream do
-  subject(:stream) { create(:stream, organization: organization) }
+  subject(:stream) { create(:stream, organization:) }
 
   let(:organization) { create(:organization) }
 
@@ -16,7 +16,7 @@ RSpec.describe Stream do
     it 'defaults to the time span' do
       # create Stream manually since factory provides display_name value
       expect(described_class.new(
-        organization: organization,
+        organization:,
         created_at: Time.zone.parse('2020-11-01'),
         updated_at: Time.zone.parse('2020-11-05')
       ).display_name).to eq '2020-11-01 - 2020-11-05'
@@ -25,7 +25,7 @@ RSpec.describe Stream do
     it 'is open-ended if the stream is the default' do
       # create Stream manually since factory provides display_name value
       expect(described_class.new(
-        organization: organization,
+        organization:,
         created_at: Time.zone.parse('2020-11-01'),
         default: true
       ).display_name).to eq '2020-11-01 - '
@@ -40,7 +40,7 @@ RSpec.describe Stream do
 
     it 'archives uploads' do
       organization = create(:organization)
-      stream_with_upload = create(:stream_with_uploads, organization: organization)
+      stream_with_upload = create(:stream_with_uploads, organization:)
       expect { stream_with_upload.archive }.to change { stream_with_upload.uploads.archived.count }.by(1)
     end
   end
@@ -79,7 +79,7 @@ RSpec.describe Stream do
   end
 
   describe '#make_default' do
-    let!(:current_default) { create(:stream, organization: organization, default: true) }
+    let!(:current_default) { create(:stream, organization:, default: true) }
 
     it 'makes the current stream the only default' do
       expect do

--- a/spec/requests/contact_emails_controller_spec.rb
+++ b/spec/requests/contact_emails_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe '/contact_emails' do
   let(:organization) { create(:organization) }
 
   describe 'GET /confirm/12345' do
-    let(:contact_email) { create(:contact_email, organization: organization) }
+    let(:contact_email) { create(:contact_email, organization:) }
 
     it 'confirms the contact email' do
       get contact_email_confirmation_url(token: contact_email.confirmation_token)

--- a/spec/requests/dashbord_controller_spec.rb
+++ b/spec/requests/dashbord_controller_spec.rb
@@ -5,9 +5,9 @@ require 'rails_helper'
 RSpec.describe '/dashboard' do
   let(:user) { create(:user) }
   let(:organization) { create(:organization) }
-  let(:stream) { create(:stream, organization: organization, default: true) }
+  let(:stream) { create(:stream, organization:, default: true) }
   let(:uploads) do
-    create_list(:upload, 1, :multiple_files, stream: stream)
+    create_list(:upload, 1, :multiple_files, stream:)
   end
 
   before do

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe '/organizations' do
         icon = fixture_file_upload(Rails.root.join('spec/fixtures/pod_logo.svg'), 'image/svg+xml')
 
         expect(organization.icon.attached?).to be false
-        patch organization_url(organization), params: { organization: new_attributes.merge(icon: icon) }
+        patch organization_url(organization), params: { organization: new_attributes.merge(icon:) }
         expect(organization.reload.icon.attached?).to be true
       end
 

--- a/spec/requests/streams_controller_spec.rb
+++ b/spec/requests/streams_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe '/organization/:id/stream' do
   let(:user) { create(:user) }
   let(:organization) { create(:organization) }
-  let(:stream) { create(:stream, organization: organization) }
+  let(:stream) { create(:stream, organization:) }
 
   before do
     sign_in create(:admin)
@@ -67,13 +67,13 @@ RSpec.describe '/organization/:id/stream' do
     let!(:default_stream) { organization.default_stream }
 
     it 'toggles on the default attribute for the new stream' do
-      post make_default_organization_streams_url(organization_id: stream.organization.id, stream: stream, format: :html)
+      post make_default_organization_streams_url(organization_id: stream.organization.id, stream:, format: :html)
       expect(response).to redirect_to(organization_url(stream.organization))
       expect(stream.reload).to have_attributes default: true
     end
 
     it 'toggles off the default stream for the previous default' do
-      post make_default_organization_streams_url(organization_id: stream.organization.id, stream: stream, format: :html)
+      post make_default_organization_streams_url(organization_id: stream.organization.id, stream:, format: :html)
       expect(default_stream.reload).to have_attributes default: false
     end
   end

--- a/spec/requests/uploads_spec.rb
+++ b/spec/requests/uploads_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe '/uploads' do
     { files: [fixture_file_upload(Rails.root.join('spec/fixtures/1297245.marc'), 'application/octet-stream')] }
   end
 
-  let(:valid_model_attributes) { valid_attributes.merge(stream: stream) }
+  let(:valid_model_attributes) { valid_attributes.merge(stream:) }
 
   let(:invalid_attributes) do
     skip

--- a/spec/support/marc_fixture_seed_fetcher.rb
+++ b/spec/support/marc_fixture_seed_fetcher.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class MarcFixtureSeedFetcher
-  def self.fetch_uploads(slug, &block)
-    new.fetch_uploads(slug, &block)
+  def self.fetch_uploads(slug, &)
+    new.fetch_uploads(slug, &)
   end
 
-  def fetch_uploads(slug, &_block)
+  def fetch_uploads(slug, &)
     default_stream_url = default_stream_for(slug)['url']
     default_stream = JSON.parse(http_client.get(default_stream_url).body)
 

--- a/spec/views/allowlisted_jwts/index.html.erb_spec.rb
+++ b/spec/views/allowlisted_jwts/index.html.erb_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'allowlisted_jwts/index' do
   let(:organization) { build(:organization) }
-  let(:stream) { create(:stream_with_uploads, organization: organization, default: true) }
+  let(:stream) { create(:stream_with_uploads, organization:, default: true) }
 
   before do
     assign(:organization, organization)

--- a/spec/views/organizations/organization_details.html.erb_spec.rb
+++ b/spec/views/organizations/organization_details.html.erb_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'organizations/organization_details' do
   let(:organization) { create(:organization, name: 'Best University') }
-  let(:contact_email) { create(:contact_email, organization: organization) }
+  let(:contact_email) { create(:contact_email, organization:) }
 
   before do
     assign(:organization, organization)

--- a/spec/views/organizations/show.html.erb_spec.rb
+++ b/spec/views/organizations/show.html.erb_spec.rb
@@ -10,17 +10,17 @@ RSpec.describe 'organizations/show' do
                                          ))
 
     # create a default stream with some uploads
-    stream = Stream.create!(name: 'stream1', organization: organization, default: true)
+    stream = Stream.create!(name: 'stream1', organization:, default: true)
 
     Upload.create!([
                      {
                        name: 'upload1',
-                       stream: stream,
+                       stream:,
                        url: 'http://example.com/upload1.zip'
                      },
                      {
                        name: 'upload2',
-                       stream: stream,
+                       stream:,
                        url: 'http://example.com/upload2.zip'
                      }
                    ])

--- a/spec/views/shared/layout_manage_organization.html.erb_spec.rb
+++ b/spec/views/shared/layout_manage_organization.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'shared/_layout_manage_organization' do
   let(:organization) do
     create(:organization, name: 'Best University', provider: is_provider)
   end
-  let(:stream) { create(:stream_with_uploads, organization: organization) }
+  let(:stream) { create(:stream_with_uploads, organization:) }
   let(:user) { create(:user) }
 
   before do

--- a/spec/views/shared/layout_stream_page.html.erb_spec.rb
+++ b/spec/views/shared/layout_stream_page.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'shared/_layout_stream_page' do
   let(:organization) do
     create(:organization, name: 'Best University')
   end
-  let(:stream) { create(:stream_with_uploads, organization: organization, default: true) }
+  let(:stream) { create(:stream_with_uploads, organization:, default: true) }
   let(:user) { create(:user) }
 
   before do

--- a/spec/views/shared/organization_header.html.erb_spec.rb
+++ b/spec/views/shared/organization_header.html.erb_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe 'shared/_organization_header' do
            code: 'Bst')
   end
 
-  let(:stream) { create(:stream_with_uploads, organization: organization) }
+  let(:stream) { create(:stream_with_uploads, organization:) }
   let(:user) { create(:user) }
-  let(:contact_email) { create(:contact_email, organization: organization) }
+  let(:contact_email) { create(:contact_email, organization:) }
 
   before do
     assign(:organization, organization)

--- a/spec/views/shared/stream_page_header.html.erb_spec.rb
+++ b/spec/views/shared/stream_page_header.html.erb_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'shared/_stream_page_header' do
   let(:organization) { create(:organization, name: 'Best University') }
-  let(:stream) { create(:stream, organization: organization) }
+  let(:stream) { create(:stream, organization:) }
 
   before do
     assign(:organization, organization)

--- a/spec/views/streams/header.html.erb_spec.rb
+++ b/spec/views/streams/header.html.erb_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'streams/header' do
   let(:organization) { create(:organization, name: 'Best University') }
-  let(:stream) { create(:stream_with_uploads, organization: organization, default: true) }
+  let(:stream) { create(:stream_with_uploads, organization:, default: true) }
   let(:user) { create(:user) }
 
   before do
@@ -14,35 +14,35 @@ RSpec.describe 'streams/header' do
 
   it 'displays the default stream name' do
     # pass local variable to partial
-    render subject, stream: stream # rubocop:disable RSpec/NamedSubject
+    render(subject, stream:) # rubocop:disable RSpec/NamedSubject
 
     expect(rendered).to include(stream.display_name)
   end
 
   it 'displays the Manage streams link' do
     allow(view).to receive(:can?).and_return(true)
-    render subject, stream: stream # rubocop:disable RSpec/NamedSubject
+    render(subject, stream:) # rubocop:disable RSpec/NamedSubject
 
     expect(rendered).to have_link 'Manage streams'
   end
 
   it 'displays the New upload button' do
     allow(view).to receive(:can?).and_return(true)
-    render subject, stream: stream # rubocop:disable RSpec/NamedSubject
+    render(subject, stream:) # rubocop:disable RSpec/NamedSubject
 
     expect(rendered).to have_link 'New upload'
   end
 
   it 'displays the Re-analyze button' do
     allow(view).to receive(:can?).and_return(true)
-    render subject, stream: stream # rubocop:disable RSpec/NamedSubject
+    render(subject, stream:) # rubocop:disable RSpec/NamedSubject
 
     expect(rendered).to have_link 'Re-analyze'
   end
 
   it 'displays the count of streams in the org' do
     allow(view).to receive(:can?).and_return(true)
-    render subject, stream: stream # rubocop:disable RSpec/NamedSubject
+    render(subject, stream:) # rubocop:disable RSpec/NamedSubject
 
     expect(rendered).to include(stream.organization.streams.active.count.to_s)
   end

--- a/spec/views/streams/summary_card.html.erb_spec.rb
+++ b/spec/views/streams/summary_card.html.erb_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'streams/summary_card' do
   let(:organization) { create(:organization, name: 'Best University') }
-  let(:stream) { create(:stream_with_uploads, organization: organization) }
+  let(:stream) { create(:stream_with_uploads, organization:) }
   let(:user) { create(:user) }
 
   before do
@@ -13,12 +13,12 @@ RSpec.describe 'streams/summary_card' do
     Upload.create!([
                      {
                        name: 'upload1',
-                       stream: stream,
+                       stream:,
                        url: 'http://example.com/upload1.zip'
                      },
                      {
                        name: 'upload2',
-                       stream: stream,
+                       stream:,
                        url: 'http://example.com/upload2.zip'
                      }
                    ])
@@ -27,28 +27,28 @@ RSpec.describe 'streams/summary_card' do
 
   it 'displays Files info' do
     # pass local variable to partial
-    render subject, stream: stream # rubocop:disable RSpec/NamedSubject
+    render(subject, stream:) # rubocop:disable RSpec/NamedSubject
 
     expect(rendered).to include(number_with_delimiter(stream.statistic&.file_count || 0))
     expect(rendered).to include('Files')
   end
 
   it 'displays Total file size info' do
-    render subject, stream: stream # rubocop:disable RSpec/NamedSubject
+    render(subject, stream:) # rubocop:disable RSpec/NamedSubject
 
     expect(rendered).to include(number_to_human_size(stream.statistic&.file_size || 0))
     expect(rendered).to include('Total file size')
   end
 
   it 'displays Records info' do
-    render subject, stream: stream # rubocop:disable RSpec/NamedSubject
+    render(subject, stream:) # rubocop:disable RSpec/NamedSubject
 
     expect(rendered).to include(number_with_delimiter(stream.statistic&.record_count || 0))
     expect(rendered).to include('Records')
   end
 
   it 'displays Unique records info' do
-    render subject, stream: stream # rubocop:disable RSpec/NamedSubject
+    render(subject, stream:) # rubocop:disable RSpec/NamedSubject
 
     expect(rendered).to include(number_with_delimiter(stream.statistic&.unique_record_count || 0))
     expect(rendered).to include('Unique records')

--- a/spec/views/uploads/index.html.erb_spec.rb
+++ b/spec/views/uploads/index.html.erb_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'uploads/index' do
   let(:organization) { create(:organization) }
-  let(:stream) { create(:stream, organization: organization) }
+  let(:stream) { create(:stream, organization:) }
 
   before do
     assign(:organization, organization)
@@ -13,12 +13,12 @@ RSpec.describe 'uploads/index' do
                      {
                        name: 'One',
                        files: [fixture_file_upload(Rails.root.join('spec/fixtures/1297245.marc'), 'application/octet-stream')],
-                       stream: stream
+                       stream:
                      },
                      {
                        name: 'Two',
                        files: [fixture_file_upload(Rails.root.join('spec/fixtures/1297245.marc'), 'application/octet-stream')],
-                       stream: stream
+                       stream:
                      }
                    ])
     assign(:uploads, stream.uploads.page(params[:page]))

--- a/spec/views/uploads/show.html.erb_spec.rb
+++ b/spec/views/uploads/show.html.erb_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe 'uploads/show' do
   let(:organization) { create(:organization) }
 
   before do
-    stream = Stream.create!(name: 'stream1', organization: organization, default: true)
+    stream = Stream.create!(name: 'stream1', organization:, default: true)
     assign(:upload, Upload.create!(
                       name: 'Name',
                       files: [fixture_file_upload(Rails.root.join('spec/fixtures/1297245.marc'), 'application/octet-stream')],
-                      stream: stream
+                      stream:
                     ))
     assign(:organization, organization)
     assign(:stream, stream)


### PR DESCRIPTION
Leaving this as a draft until there is a ruby 3.3.1 release. There are some issues with anonymous parameter forwarding, which rubocop would like us to use.

See:

- https://bugs.ruby-lang.org/issues/20090
- https://bugs.ruby-lang.org/issues/19370