### PR TITLE
Change upload validation to avoid input error on form

### DIFF
--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Upload do
     it 'validates that a URL or files are present' do
       expect do
         create(:upload, files: [])
-      end.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Url can't be blank, Files can't be blank")
+      end.to raise_error(ActiveRecord::RecordInvalid,
+                         "Validation failed: Url A URL must be provided if a file has not been uploaded, Files can't be blank")
     end
 
     context 'with an invalid URL' do


### PR DESCRIPTION
Fixes #1025.

When using the `if: proc ...` validation, the default JavaScript validation isn't aware of the state change when you add a file (AFAIK). The approach here uses a custom validation, which will change the presentation slightly:

![Screenshot 2024-03-12 at 12 54 00 PM](https://github.com/pod4lib/aggregator/assets/4421877/01c702ec-eb7c-48de-8d9e-b188e34c5548)

This is a tiny fix. Might be nice to handle the client-side issue, but maybe that's better left for when we do the bigger move off turbolinks?