### PR TITLE
Update the digest algorithm to use the newer defaults

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -28,7 +28,7 @@ Rails.application.config.action_view.apply_stylesheet_media_default = false
 # Change the digest class for ActiveSupport::Digest.
 # Changing this default means that for example Etags change and
 # various cache keys leading to cache invalidation.
-# Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
 
 # Don't override ActiveSupport::TimeWithZone.name and use the default Ruby
 # implementation.

--- a/spec/requests/files_spec.rb
+++ b/spec/requests/files_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe '/files' do
           'Accept-Ranges' => 'bytes',
           'Content-Disposition' => 'attachment',
           'Content-Type' => 'application/marc',
-          'Etag' => 'W/"38c691f04e7e59e58c3fea6eb54b5421"'
+          'Etag' => 'W/"f97fb02f92d85d88a8d6c06d60a5aed2"'
         }
       end
 


### PR DESCRIPTION
See https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256