### PR TITLE
Fix check for postgres database

### DIFF
--- a/app/services/normalized_marc_record_reader.rb
+++ b/app/services/normalized_marc_record_reader.rb
@@ -58,7 +58,7 @@ class NormalizedMarcRecordReader
 
   def using_postgres?
     defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) &&
-      ActiveRecord::Base.connection == ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+      ActiveRecord::Base.connection.instance_of?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
   end
 
   def __pgsql_current_marc_record_ids


### PR DESCRIPTION
We'd like this condition to pass when the postgres adapter is being used.
```
3.3.0 :001 > ActiveRecord::Base.connection == ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
 => false 
```

```
3.3.0 :002 > ActiveRecord::Base.connection.instance_of?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
 => true 
```