### PR TITLE
Revert to deploy to prod on release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,13 +53,13 @@ pipeline {
       }
     }
 
-    stage('Deploy to -prod') {
+    stage('Deploy on release') {
       environment {
         DEPLOY_ENVIRONMENT = 'prod'
       }
 
       when {
-        branch 'main'
+        tag "v*"
       }
 
       steps {


### PR DESCRIPTION
Reverts most of https://github.com/pod4lib/aggregator/pull/1066 so that we only deploy to prod upon release. Deploy upon merge to main has been problematic for POD where there are sometimes long running jobs that get interrupted by deploys.